### PR TITLE
Update tests for testrpc@6.0.1 (revert opcode)

### DIFF
--- a/test/LANDTerraformSale.js
+++ b/test/LANDTerraformSale.js
@@ -6,7 +6,7 @@ const should = require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
-const { EVMThrow, sum } = require('./utils')
+const { EVMRevert, sum } = require('./utils')
 
 const Mana = artifacts.require('./FAKEMana')
 const Land = artifacts.require('./LANDToken')
@@ -83,16 +83,16 @@ contract('LANDTerraformSale', function ([owner, terraformReserve, buyer1, buyer2
 
   describe('return MANA back to buyers', function () {
     it('should throw if not the owner returning funds', async function () {
-      await sale.transferBackMANA(buyer1, landCost, {from: buyer2}).should.be.rejectedWith(EVMThrow)
+      await sale.transferBackMANA(buyer1, landCost, {from: buyer2}).should.be.rejectedWith(EVMRevert)
     })
 
     it('should throw if amount to return is not positive', async function () {
-      await sale.transferBackMANA(buyer1, 0).should.be.rejectedWith(EVMThrow)
-      await sale.transferBackMANA(buyer1, -1).should.be.rejectedWith(EVMThrow)
+      await sale.transferBackMANA(buyer1, 0).should.be.rejectedWith(EVMRevert)
+      await sale.transferBackMANA(buyer1, -1).should.be.rejectedWith(EVMRevert)
     })
 
     it('should throw if return address is invalid', async function () {
-      await sale.transferBackMANA(0x0, landCost).should.be.rejectedWith(EVMThrow)
+      await sale.transferBackMANA(0x0, landCost).should.be.rejectedWith(EVMRevert)
     })
 
     it('should return funds to buyer', async function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,4 @@
+export const EVMRevert = 'revert'
 export const EVMThrow = 'invalid opcode'
 
 export function sum (values) {


### PR DESCRIPTION
Version 6 of TestRPC throws a different error message when using revert() to match the addition of this opcode. Handle this properly in the tests.