### PR TITLE
Terraform contract that performs buys with no burning

### DIFF
--- a/contracts/LANDTerraformSale.sol
+++ b/contracts/LANDTerraformSale.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.4.15;
 
 import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 import './LANDSale.sol';
-import './ReturnVestingRegistry.sol';
 
 /**
  * @title LANDTerraformSale
@@ -10,23 +9,10 @@ import './ReturnVestingRegistry.sol';
  */
 contract LANDTerraformSale is LANDSale, Ownable {
 
-  // contract for mapping return address of vested accounts
-  ReturnVestingRegistry public returnVesting;
-
-  // address of the contract that holds the reserve of staked MANA
-  address public terraformReserve;
-
   /** 
     * @dev Constructor
-    * @param _token MANA token contract address
-    * @param _terraformReserve address of the contract that holds the staked funds for the auction
-    * @param _returnVesting address of the contract for vested account mapping
     */
-  function LANDTerraformSale(address _token, address _terraformReserve, address _returnVesting) public {
-    token = BurnableToken(_token);
-    returnVesting = ReturnVestingRegistry(_returnVesting);
-    terraformReserve = _terraformReserve;
-
+  function LANDTerraformSale() public {
     land = _deployLand();
   }
 
@@ -35,10 +21,12 @@ contract LANDTerraformSale is LANDSale, Ownable {
     * @param _buyer Address of the buyer
     * @param _x X coordinate of LAND
     * @param _y Y coordinate of LAND
-    * @param _cost Amount of MANA to burn
     */
-  function buy(address _buyer, uint256 _x, uint256 _y, uint256 _cost) onlyOwner public {
-    _buyLand(_x, _y, '', _buyer, terraformReserve, _cost);
+  function buy(address _buyer, uint256 _x, uint256 _y) onlyOwner public {
+    require(!exists(_x, _y));
+    require(_isValidLand(_x, _y));
+
+    land.assignNewParcel(_buyer, buildTokenId(_x, _y), '');
   }
 
   /** 
@@ -46,59 +34,16 @@ contract LANDTerraformSale is LANDSale, Ownable {
     * @param _buyer Address of the buyer
     * @param _x Array of X coordinates of LAND to buy
     * @param _y Array of Y coordinates of LAND to buy
-    * @param _totalCost Total amount of MANA to burn
     */
-  function buyMany(address _buyer, uint256[] _x, uint256[] _y, uint256 _totalCost) onlyOwner public {
+  function buyMany(address _buyer, uint256[] _x, uint256[] _y) onlyOwner public {
     require(_x.length == _y.length);
-
-    // Transfer funds from reserve to this contract to allow burning MANA
-    if (!token.transferFrom(terraformReserve, this, _totalCost)) {
-      revert();
-    }
-    token.burn(_totalCost);
 
     for (uint256 i = 0; i < _x.length; i++) {
       land.assignNewParcel(_buyer, buildTokenId(_x[i], _y[i]), '');
     }
   }
 
-  /** 
-    * @dev Transfer back remaining MANA to account
-    * @param _address Address of the account to return MANA to
-    * @param _amount Amount of MANA to return
-    */
-  function transferBackMANA(address _address, uint256 _amount) onlyOwner public {
-    require(_address != address(0));
-    require(_amount > 0);
-
-    address returnAddress = _address;
-
-    // Use vesting return address if present
-    if (returnVesting != address(0)) {
-      address mappedAddress = returnVesting.returnAddress(_address);
-      if (mappedAddress != address(0)) {
-        returnAddress = mappedAddress;
-      }
-    }
-
-    // Funds are always transferred from reserve
-    require(token.transferFrom(terraformReserve, returnAddress, _amount));
-  }
-
-  /** 
-    * @dev Transfer back remaining MANA to multiple accounts
-    * @param _addresses Addresses of the accounts to return MANA to
-    * @param _amounts Amounts of MANA to return
-    */
-  function transferBackMANAMany(address[] _addresses, uint256[] _amounts) onlyOwner public {
-    require(_addresses.length == _amounts.length);
-
-    for (uint256 i = 0; i < _addresses.length; i++) {
-      transferBackMANA(_addresses[i], _amounts[i]);
-    }
-  }
-
-  /** 
+  /**
     * @dev Transfer ownership of LAND contract
     * @param _newOwner The address of the new owner of the LAND contract
     */

--- a/test/LANDTerraformSale.js
+++ b/test/LANDTerraformSale.js
@@ -8,34 +8,26 @@ const should = require('chai')
 
 const { EVMRevert, sum } = require('./utils')
 
-const Mana = artifacts.require('./FAKEMana')
-const Land = artifacts.require('./LANDToken')
+const MANAToken = artifacts.require('./FAKEMana')
+const LANDRegistry = artifacts.require('./LANDToken')
 const LANDContinuousSale = artifacts.require('./LANDContinuousSale')
 const LANDTerraformSale = artifacts.require('./LANDTerraformSale')
-const ReturnVestingRegistry = artifacts.require('./ReturnVestingRegistry')
 
 contract('LANDTerraformSale', function ([owner, terraformReserve, buyer1, buyer2, vested2]) {
-  const landCost = 1000 * 1e18
-  const totalMANALocked = 10000 * 1e18
+  const metadata = ''
 
-  let mana, sale, world, returnVesting
+  let mana, sale, world
 
   beforeEach(async () => {
-    mana = await Mana.new()
-    returnVesting = await ReturnVestingRegistry.new()
-    await returnVesting.record(buyer2, vested2)
-
-    sale = await LANDTerraformSale.new(mana.address, terraformReserve, returnVesting.address)
-    world = await Land.at(await sale.land())
-
-    await mana.setBalance(terraformReserve, totalMANALocked)
-    await mana.approve(sale.address, totalMANALocked, {from: terraformReserve})
+    mana = await MANAToken.new()
+    sale = await LANDTerraformSale.new()
+    world = await LANDRegistry.at(await sale.land())
   })
 
   describe('buyer want to buy LAND', function () {
     it('should assign non-adjacent LAND to buyer', async function () {
-      await sale.buy(buyer1, 0, 0, landCost, { from: owner })
-      await sale.buy(buyer1, 0, 10, landCost, { from: owner })
+      await sale.buy(buyer1, 0, 0, { from: owner })
+      await sale.buy(buyer1, 0, 5, { from: owner })
 
       // Check LAND created
       const numberOfLand = await world.totalSupply()
@@ -47,19 +39,15 @@ contract('LANDTerraformSale', function ([owner, terraformReserve, buyer1, buyer2
       newOwner = await world.ownerOfLand(0, 0)
       newOwner.should.be.equal(buyer1)
 
-      newOwner = await world.ownerOfLand(0, 10)
+      newOwner = await world.ownerOfLand(0, 5)
       newOwner.should.be.equal(buyer1)
     })
 
     it('should assign LAND to buyer in bulk', async function () {
       const x = [1, 1, 1, 1]
       const y = [0, 1, 2, 3]
-      const cost = Array(x.length).fill(landCost)
-      const totalCost = sum(cost)
 
-      const oldBalance = await mana.balanceOf(terraformReserve)
-      await sale.buyMany(buyer2, x, y, totalCost)
-      const newBalance = await mana.balanceOf(terraformReserve)
+      await sale.buyMany(buyer2, x, y)
 
       // Check LAND created
       const numberOfLand = await world.totalSupply()
@@ -71,9 +59,6 @@ contract('LANDTerraformSale', function ([owner, terraformReserve, buyer1, buyer2
         newOwner = await world.ownerOfLand(x[i], y[i])
         newOwner.should.be.equal(buyer2)
       }
-
-      // Check MANA burnt
-      newBalance.should.be.bignumber.equal(oldBalance - totalCost)
     })
 
     it('should recover empty metadata', async function () {
@@ -82,69 +67,20 @@ contract('LANDTerraformSale', function ([owner, terraformReserve, buyer1, buyer2
     })
   })
 
-  describe('return MANA back to buyers', function () {
-    it('should throw if not the owner returning funds', async function () {
-      await sale.transferBackMANA(buyer1, landCost, {from: buyer2}).should.be.rejectedWith(EVMRevert)
-    })
-
-    it('should throw if amount to return is not positive', async function () {
-      await sale.transferBackMANA(buyer1, 0).should.be.rejectedWith(EVMRevert)
-      await sale.transferBackMANA(buyer1, -1).should.be.rejectedWith(EVMRevert)
-    })
-
-    it('should throw if return address is invalid', async function () {
-      await sale.transferBackMANA(0x0, landCost).should.be.rejectedWith(EVMRevert)
-    })
-
-    it('should return funds to buyer', async function () {
-      const oldBalance = await mana.balanceOf(buyer1)
-      await sale.transferBackMANA(buyer1, landCost)
-      const newBalance = await mana.balanceOf(buyer1)
-      newBalance.should.be.bignumber.equal(oldBalance + landCost)
-    })
-
-    it('should return funds to vested buyer', async function () {
-      const oldBalance = await mana.balanceOf(vested2)
-      await sale.transferBackMANA(buyer2, landCost)
-      const newBalance = await mana.balanceOf(vested2)
-      newBalance.should.be.bignumber.equal(oldBalance + landCost)
-    })
-
-    it('should transfer funds in bulk and take into account vesting accounts', async function () {
-      // before state
-      const oldBalance1 = await mana.balanceOf(buyer1)
-      const oldBalance2 = await mana.balanceOf(vested2)
-
-      // transfer
-      const addresses = [buyer1, buyer2]
-      const amounts = [landCost, landCost]
-      await sale.transferBackMANAMany(addresses, amounts)
- 
-      // after state
-      const newBalance1 = await mana.balanceOf(buyer1)
-      const newBalance2 = await mana.balanceOf(vested2)
-      newBalance1.should.be.bignumber.equal(oldBalance1 + landCost)
-      newBalance2.should.be.bignumber.equal(oldBalance2 + landCost)
-    })
-
-    it('should throw if addresses and amounts have different length', async function () {
-      const addresses = [buyer1, buyer2]
-      const amounts = [landCost]
-      await sale.transferBackMANAMany(addresses, amounts).should.be.rejectedWith(EVMRevert) 
-    })
-  })
-
   describe('transfer ownership of LANDToken contract', function () {
-    it('should allow transfering ownership of LANDToken contract', async function () {
-      const metadata = ''
-    
-      await sale.buy(buyer1, 0, 0, landCost, { from: owner })
+    it('should allow transfering ownership of LANDToken contract', async function () {    
+      const landCost = 1000 * 1e18
 
-      await mana.setBalance(buyer1, landCost)
+      // terraform contract buy ok
+      await sale.buy(buyer1, 0, 0, { from: owner })
+
+      // continuous sale buy is not ok until transferred ownership
       const newSale = await LANDContinuousSale.new(mana.address, world.address)
+      await mana.setBalance(buyer1, landCost)
       await mana.approve(newSale.address, landCost, { from: buyer1 })
       await newSale.buy(0, 1, metadata, { from: buyer1 }).should.be.rejectedWith(EVMRevert)
 
+      // allow buy after transfering ownership
       await sale.transferLandOwnership(newSale.address)
       await newSale.buy(0, 1, metadata, { from: buyer1 }).should.not.be.rejectedWith(EVMRevert)
     })


### PR DESCRIPTION
After the auction, we burned the MANA and returned the funds using the ReturnMANA contract. 

When we perform the assignation of LAND to owners the LANDTerraformSale contract should not burn the MANA but only assign the rights.