### PR TITLE
(TEST) Land centric getters

### DIFF
--- a/test/LANDRegistryTest.sol
+++ b/test/LANDRegistryTest.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.18;
+
+import '../contracts/land/LANDRegistry.sol';
+
+contract LANDRegistryTest is LANDRegistry {
+  function existsProxy(int x, int y) view public returns (bool) {
+    return exists(encodeTokenId(x, y));
+  }
+}


### PR DESCRIPTION
Had to create a test contract to workaround the truffle overloading issue
Includes tests for:
- `exists(x, y)`
- `landData(x, y)`