### PR TITLE
chore: make ping function public

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -131,7 +131,7 @@ contract EstateRegistry is Migratable, ERC721Token, Ownable, MetadataHolderBase,
     emit SetLANDRegistry(registry);
   }
 
-  function ping() external onlyOwner {
+  function ping() external {
     registry.ping();
   }
 


### PR DESCRIPTION
Make the `ping()` function public as the one in the LANDRegistry.