### PR TITLE
Feat/edit land owned by estate metadata

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -380,7 +380,7 @@ contract EstateRegistry is Migratable, ERC721Token, ERC721Receiver, Ownable, IEs
    * @param y coordinate of the LAND
    * @param data string metadata
    */
-  function updateLandData(uint256 estateId, int x, int y, string data) public onlyUpdateAuthorized(estateId) {
+  function updateLandData(uint256 estateId, int x, int y, string data) external onlyUpdateAuthorized(estateId) {
     registry.updateLandData(x, y, data);
   }
 
@@ -391,7 +391,7 @@ contract EstateRegistry is Migratable, ERC721Token, ERC721Receiver, Ownable, IEs
    * @param y coordinates of the LAND
    * @param data string metadata
    */
-  function updateManyLandData(uint256 estateId, int[] x, int[] y, string data) public onlyUpdateAuthorized(estateId) {
+  function updateManyLandData(uint256 estateId, int[] x, int[] y, string data) external onlyUpdateAuthorized(estateId) {
     registry.updateManyLandData(x, y, data);
   }
 }

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -318,7 +318,7 @@ contract EstateRegistry is Migratable, ERC721Token, ERC721Receiver, Ownable, IEs
     /**
      * Using 1-based indexing to be able to make this check
      */
-    require(landIndex[landId] != 0, "The LAND is already owned by the Estate");
+    require(landIndex[landId] != 0, "The LAND is not part of the Estate");
 
     uint lastIndexInArray = landIds.length.sub(1);
 
@@ -376,22 +376,31 @@ contract EstateRegistry is Migratable, ERC721Token, ERC721Receiver, Ownable, IEs
   /**
    * @dev update LAND data owned by an Estate
    * @param estateId Estate
-   * @param x coordinate of the LAND
-   * @param y coordinate of the LAND
+   * @param landId LAND to be updated
    * @param data string metadata
    */
-  function updateLandData(uint256 estateId, int x, int y, string data) external onlyUpdateAuthorized(estateId) {
-    registry.updateLandData(x, y, data);
+  function updateLandData(uint256 estateId, uint256 landId, string data) public {
+    _updateLandData(estateId, landId, data);
   }
 
   /**
    * @dev update LANDs data owned by an Estate
    * @param estateId Estate id
-   * @param x coordinates of the LAND
-   * @param y coordinates of the LAND
+   * @param landIds LANDs to be updated
    * @param data string metadata
    */
-  function updateManyLandData(uint256 estateId, int[] x, int[] y, string data) external onlyUpdateAuthorized(estateId) {
-    registry.updateManyLandData(x, y, data);
+  function updateManyLandData(uint256 estateId, uint256[] landIds, string data) public {
+    uint length = landIds.length;
+    for (uint i = 0; i < length; i++) {
+      _updateLandData(estateId, landIds[i], data);
+    }
+  }
+
+  function _updateLandData(uint256 estateId, uint256 landId, string data) internal onlyUpdateAuthorized(estateId) {
+    require(landIdEstate[landId] == estateId, "The LAND is not part of the Estate");
+    int x;
+    int y;
+    (x, y) = registry.decodeTokenId(landId);
+    registry.updateLandData(x, y, data);
   }
 }

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -372,4 +372,26 @@ contract EstateRegistry is Migratable, ERC721Token, ERC721Receiver, Ownable, IEs
 
     return uint256(out);
   }
+
+  /**
+   * @dev update LAND data owned by an Estate
+   * @param estateId Estate
+   * @param x coordinate of the LAND
+   * @param y coordinate of the LAND
+   * @param data string metadata
+   */
+  function updateLandData(uint256 estateId, int x, int y, string data) public onlyUpdateAuthorized(estateId) {
+    registry.updateLandData(x, y, data);
+  }
+
+  /**
+   * @dev update LANDs data owned by an Estate
+   * @param estateId Estate id
+   * @param x coordinates of the LAND
+   * @param y coordinates of the LAND
+   * @param data string metadata
+   */
+  function updateManyLandData(uint256 estateId, int[] x, int[] y, string data) public onlyUpdateAuthorized(estateId) {
+    registry.updateManyLandData(x, y, data);
+  }
 }

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -5,8 +5,8 @@ contract LANDRegistry {
   function ping() public;
   function ownerOf(uint256 tokenId) public returns (address);
   function safeTransferFrom(address, address, uint256) public;
-  function updateLandData(int x, int y, string data) public;
-  function updateManyLandData(int[] x, int[] y, string data) public;
+  function updateLandData(int x, int y, string data) external;
+  function updateManyLandData(int[] x, int[] y, string data) external;
 }
 
 

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -5,6 +5,8 @@ contract LANDRegistry {
   function ping() public;
   function ownerOf(uint256 tokenId) public returns (address);
   function safeTransferFrom(address, address, uint256) public;
+  function updateLandData(int x, int y, string data) public;
+  function updateManyLandData(int[] x, int[] y, string data) public;
 }
 
 

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -5,8 +5,8 @@ contract LANDRegistry {
   function ping() public;
   function ownerOf(uint256 tokenId) public returns (address);
   function safeTransferFrom(address, address, uint256) public;
+  function decodeTokenId(uint value) external pure returns (int, int);
   function updateLandData(int x, int y, string data) external;
-  function updateManyLandData(int[] x, int[] y, string data) external;
 }
 
 

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -185,7 +185,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   function _tokenMetadata(uint256 assetId) internal view returns (string) {
     address _owner = _ownerOf(assetId);
-    if (_isContract(_owner)) {
+    if (_isContract(_owner) && _owner != address(estateRegistry)) {
       if ((ERC165(_owner)).supportsInterface(GET_METADATA)) {
         return IMetadataHolder(_owner).getMetadata(assetId);
       }

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -493,21 +493,15 @@ contract('EstateRegistry', accounts => {
     })
   })
 
-  describe.only('land update', function() {
-    it.only('should allow owner of Estate to update land data', async function() {
+  describe('LAND update', function() {
+    it('should allow owner of Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       const estateId = await createEstate([0], [1], user, sentByUser)
-      await estate.updateLandData(
-        estateId,
-        0,
-        1,
-        'newValue2',
-        sentByUser
-      )
+      await estate.updateLandData(estateId, 0, 1, 'newValue', sentByUser)
       const data = await land.landData(0, 1, sentByUser)
-      data.should.be.equal('newValue2')
+      data.should.be.equal('newValue')
     })
-    it('should allow operator of Estate to update land data', async function() {
+    it('should allow operator of Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await estate.setApprovalForAll(anotherUser, true, sentByUser)
@@ -515,7 +509,7 @@ contract('EstateRegistry', accounts => {
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
-    it('should allow update operator of Estate to update land data', async function() {
+    it('should allow update operator of Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await estate.setUpdateOperator(1, anotherUser, sentByUser)
@@ -523,24 +517,108 @@ contract('EstateRegistry', accounts => {
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
-    it('should not allow not operator, not owner or not updateOperator of Estate to update land data', async function() {
+    it('should not allow not operator, not owner or not updateOperator of Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await assertRevert(
         estate.updateLandData(1, 0, 1, 'newValue', sentByAnotherUser)
       )
     })
-    it('should not allow old owner to update land after creating an Estate', async function() {
+    it('should not allow old owner to update LAND data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await assertRevert(land.updateLandData(0, 1, 'newValue', sentByUser))
     })
-    it('should not allow old operator to update land after creating Estate', async function() {
+    it('should not allow old operator to update LAND data after creating Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await land.setApprovalForAll(anotherUser, true, sentByUser)
       await createEstate([0], [1], user, sentByAnotherUser)
       await assertRevert(
         land.updateLandData(0, 1, 'newValue', sentByAnotherUser)
+      )
+    })
+  })
+
+  describe('LANDs update', function() {
+    it('should allow owner of Estate to update LANDs data', async function() {
+      await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
+      const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
+      await estate.updateManyLandData(
+        estateId,
+        [0, 0],
+        [1, 2],
+        'newValue',
+        sentByUser
+      )
+      const landsData = await Promise.all([
+        land.landData(0, 1, sentByUser),
+        land.landData(0, 2, sentByUser)
+      ])
+
+      landsData.forEach(data => data.should.be.equal('newValue'))
+    })
+    it('should allow operator of Estate to update LANDs data', async function() {
+      await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
+      const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
+      await estate.setApprovalForAll(anotherUser, true, sentByUser)
+      await estate.updateManyLandData(
+        estateId,
+        [0, 0],
+        [1, 2],
+        'newValue',
+        sentByAnotherUser
+      )
+      const landsData = await Promise.all([
+        land.landData(0, 1, sentByUser),
+        land.landData(0, 2, sentByUser)
+      ])
+
+      landsData.forEach(data => data.should.be.equal('newValue'))
+    })
+    it('should allow update operator of Estate to update LANDs data', async function() {
+      await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
+      const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
+      await estate.setUpdateOperator(1, anotherUser, sentByUser)
+      await estate.updateManyLandData(
+        estateId,
+        [0, 0],
+        [1, 2],
+        'newValue',
+        sentByAnotherUser
+      )
+      const landsData = await Promise.all([
+        land.landData(0, 1, sentByUser),
+        land.landData(0, 2, sentByUser)
+      ])
+
+      landsData.forEach(data => data.should.be.equal('newValue'))
+    })
+    it('should not allow not operator, not owner or not updateOperator of Estate to update LANDs data', async function() {
+      await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
+      const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
+      await assertRevert(
+        estate.updateManyLandData(
+          estateId,
+          [0, 0],
+          [1, 2],
+          'newValue',
+          sentByAnotherUser
+        )
+      )
+    })
+    it('should not allow old owner to update LANDs data after creating an Estate', async function() {
+      await land.assignMultipleParcels([0], [1], user, sentByCreator)
+      await createEstate([0], [1], user, sentByUser)
+      await assertRevert(
+        land.updateManyLandData([0], [1], 'newValue', sentByUser)
+      )
+    })
+    it('should not allow old operator to update LANDs data after creating Estate', async function() {
+      await land.assignMultipleParcels([0], [1], user, sentByCreator)
+      await land.setApprovalForAll(anotherUser, true, sentByUser)
+      await createEstate([0], [1], user, sentByAnotherUser)
+      await assertRevert(
+        land.updateManyLandData([0], [1], 'newValue', sentByAnotherUser)
       )
     })
   })

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -494,14 +494,14 @@ contract('EstateRegistry', accounts => {
   })
 
   describe('LAND update', function() {
-    it('should allow owner of Estate to update LAND data', async function() {
+    it('should allow owner of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       const estateId = await createEstate([0], [1], user, sentByUser)
       await estate.updateLandData(estateId, 0, 1, 'newValue', sentByUser)
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
-    it('should allow operator of Estate to update LAND data', async function() {
+    it('should allow operator of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await estate.setApprovalForAll(anotherUser, true, sentByUser)
@@ -509,7 +509,7 @@ contract('EstateRegistry', accounts => {
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
-    it('should allow update operator of Estate to update LAND data', async function() {
+    it('should allow update operator of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await estate.setUpdateOperator(1, anotherUser, sentByUser)
@@ -517,7 +517,7 @@ contract('EstateRegistry', accounts => {
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
-    it('should not allow not operator, not owner or not updateOperator of Estate to update LAND data', async function() {
+    it('should not allow neither operator, nor owner nor updateOperator of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await assertRevert(
@@ -529,7 +529,7 @@ contract('EstateRegistry', accounts => {
       await createEstate([0], [1], user, sentByUser)
       await assertRevert(land.updateLandData(0, 1, 'newValue', sentByUser))
     })
-    it('should not allow old operator to update LAND data after creating Estate', async function() {
+    it('should not allow old operator to update LAND data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await land.setApprovalForAll(anotherUser, true, sentByUser)
       await createEstate([0], [1], user, sentByAnotherUser)
@@ -540,7 +540,7 @@ contract('EstateRegistry', accounts => {
   })
 
   describe('LANDs update', function() {
-    it('should allow owner of Estate to update LANDs data', async function() {
+    it('should allow owner of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
       await estate.updateManyLandData(
@@ -557,7 +557,7 @@ contract('EstateRegistry', accounts => {
 
       landsData.forEach(data => data.should.be.equal('newValue'))
     })
-    it('should allow operator of Estate to update LANDs data', async function() {
+    it('should allow operator of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
       await estate.setApprovalForAll(anotherUser, true, sentByUser)
@@ -575,7 +575,7 @@ contract('EstateRegistry', accounts => {
 
       landsData.forEach(data => data.should.be.equal('newValue'))
     })
-    it('should allow update operator of Estate to update LANDs data', async function() {
+    it('should allow update operator of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
       await estate.setUpdateOperator(1, anotherUser, sentByUser)
@@ -593,7 +593,7 @@ contract('EstateRegistry', accounts => {
 
       landsData.forEach(data => data.should.be.equal('newValue'))
     })
-    it('should not allow not operator, not owner or not updateOperator of Estate to update LANDs data', async function() {
+    it('should not allow neither operator nor owner nor updateOperator of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
       await assertRevert(
@@ -613,7 +613,7 @@ contract('EstateRegistry', accounts => {
         land.updateManyLandData([0], [1], 'newValue', sentByUser)
       )
     })
-    it('should not allow old operator to update LANDs data after creating Estate', async function() {
+    it('should not allow old operator to update LANDs data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await land.setApprovalForAll(anotherUser, true, sentByUser)
       await createEstate([0], [1], user, sentByAnotherUser)

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -324,6 +324,13 @@ contract('EstateRegistry', accounts => {
         estate.transferLand(estateId, 1, yetAnotherUser, sentByAnotherUser)
       )
     })
+
+    it('should not allow an owner of an Estate transfer tokens out from an Estate which is not the owner', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await land.assignMultipleParcels([0], [2], anotherUser, sentByCreator)
+      await createEstate([0], [2], anotherUser, sentByAnotherUser)
+      await assertRevert(estate.transferLand(estateId, 2, user, sentByUser))
+    })
   })
 
   describe('transfer tokens', function() {
@@ -497,44 +504,59 @@ contract('EstateRegistry', accounts => {
     it('should allow owner of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       const estateId = await createEstate([0], [1], user, sentByUser)
-      await estate.updateLandData(estateId, 0, 1, 'newValue', sentByUser)
+      await estate.updateLandData(estateId, 1, 'newValue', sentByUser)
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
+
     it('should allow operator of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
-      await createEstate([0], [1], user, sentByUser)
+      const estateId = await createEstate([0], [1], user, sentByUser)
       await estate.setApprovalForAll(anotherUser, true, sentByUser)
-      await estate.updateLandData(1, 0, 1, 'newValue', sentByAnotherUser)
+      await estate.updateLandData(estateId, 1, 'newValue', sentByAnotherUser)
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
+
     it('should allow update operator of an Estate to update LAND data', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
-      await createEstate([0], [1], user, sentByUser)
-      await estate.setUpdateOperator(1, anotherUser, sentByUser)
-      await estate.updateLandData(1, 0, 1, 'newValue', sentByAnotherUser)
+      const estateId = await createEstate([0], [1], user, sentByUser)
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
+      await estate.updateLandData(estateId, 1, 'newValue', sentByAnotherUser)
       const data = await land.landData(0, 1, sentByUser)
       data.should.be.equal('newValue')
     })
-    it('should not allow neither operator, nor owner nor updateOperator of an Estate to update LAND data', async function() {
+
+    it('should not allow owner an Estate to update LAND data of an Estate which is not the owner', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
-      await createEstate([0], [1], user, sentByUser)
+      const estateIdByUser = await createEstate([0], [1], user, sentByUser)
+      await land.assignMultipleParcels([0], [2], anotherUser, sentByCreator)
+      await createEstate([0], [2], anotherUser, sentByAnotherUser)
       await assertRevert(
-        estate.updateLandData(1, 0, 1, 'newValue', sentByAnotherUser)
+        estate.updateLandData(estateIdByUser, 2, 'newValue', sentByUser)
       )
     })
+
+    it('should not allow neither operator, nor owner nor updateOperator of an Estate to update LAND data', async function() {
+      await land.assignMultipleParcels([0], [1], user, sentByCreator)
+      const estateId = await createEstate([0], [1], user, sentByUser)
+      await assertRevert(
+        estate.updateLandData(estateId, 1, 'newValue', sentByAnotherUser)
+      )
+    })
+
     it('should not allow old owner to update LAND data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
       await assertRevert(land.updateLandData(0, 1, 'newValue', sentByUser))
     })
+
     it('should not allow old operator to update LAND data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await land.setApprovalForAll(anotherUser, true, sentByUser)
-      await createEstate([0], [1], user, sentByAnotherUser)
+      const estateId = await createEstate([0], [1], user, sentByAnotherUser)
       await assertRevert(
-        land.updateLandData(0, 1, 'newValue', sentByAnotherUser)
+        land.updateLandData(estateId, 1, 'newValue', sentByAnotherUser)
       )
     })
   })
@@ -543,13 +565,7 @@ contract('EstateRegistry', accounts => {
     it('should allow owner of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
-      await estate.updateManyLandData(
-        estateId,
-        [0, 0],
-        [1, 2],
-        'newValue',
-        sentByUser
-      )
+      await estate.updateManyLandData(estateId, [1, 2], 'newValue', sentByUser)
       const landsData = await Promise.all([
         land.landData(0, 1, sentByUser),
         land.landData(0, 2, sentByUser)
@@ -557,13 +573,13 @@ contract('EstateRegistry', accounts => {
 
       landsData.forEach(data => data.should.be.equal('newValue'))
     })
+
     it('should allow operator of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
       await estate.setApprovalForAll(anotherUser, true, sentByUser)
       await estate.updateManyLandData(
         estateId,
-        [0, 0],
         [1, 2],
         'newValue',
         sentByAnotherUser
@@ -575,13 +591,13 @@ contract('EstateRegistry', accounts => {
 
       landsData.forEach(data => data.should.be.equal('newValue'))
     })
+
     it('should allow update operator of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
-      await estate.setUpdateOperator(1, anotherUser, sentByUser)
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
       await estate.updateManyLandData(
         estateId,
-        [0, 0],
         [1, 2],
         'newValue',
         sentByAnotherUser
@@ -593,19 +609,30 @@ contract('EstateRegistry', accounts => {
 
       landsData.forEach(data => data.should.be.equal('newValue'))
     })
+
+    it('should not allow owner an Estate to update LANDs data of an Estate which is not the owner', async function() {
+      await land.assignMultipleParcels([0], [1], user, sentByCreator)
+      const estateIdByUser = await createEstate([0], [1], user, sentByUser)
+      await land.assignMultipleParcels([0], [2], anotherUser, sentByCreator)
+      await createEstate([0], [2], anotherUser, sentByAnotherUser)
+      await assertRevert(
+        estate.updateManyLandData(estateIdByUser, [2], 'newValue', sentByUser)
+      )
+    })
+
     it('should not allow neither operator nor owner nor updateOperator of an Estate to update LANDs data', async function() {
       await land.assignMultipleParcels([0, 0], [1, 2], user, sentByCreator)
       const estateId = await createEstate([0, 0], [1, 2], user, sentByUser)
       await assertRevert(
         estate.updateManyLandData(
           estateId,
-          [0, 0],
           [1, 2],
           'newValue',
           sentByAnotherUser
         )
       )
     })
+
     it('should not allow old owner to update LANDs data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await createEstate([0], [1], user, sentByUser)
@@ -613,6 +640,7 @@ contract('EstateRegistry', accounts => {
         land.updateManyLandData([0], [1], 'newValue', sentByUser)
       )
     })
+
     it('should not allow old operator to update LANDs data after creating an Estate', async function() {
       await land.assignMultipleParcels([0], [1], user, sentByCreator)
       await land.setApprovalForAll(anotherUser, true, sentByUser)

--- a/test/EstateRegistryTest.sol
+++ b/test/EstateRegistryTest.sol
@@ -17,7 +17,7 @@ contract EstateRegistryTest is EstateRegistry {
     return _mintEstate(to, metadata);
   }
 
-  function getMetadataInterfaceId() pure returns (bytes4) {
+  function getMetadataInterfaceId() public pure returns (bytes4) {
     return InterfaceId_GetMetadata;
   }
 }


### PR DESCRIPTION
- Add the possibility to update land data when it is part of an Estate
- Allow EstateRegistry to get land data at `_tokenMetadata`
- Update fulls