### PR TITLE
Fix: update operator

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -139,13 +139,13 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     return estateData[estateId];
   }
 
-  function setUpdateOperator(uint256 estateId, address operator) external canTransfer(estateId) {
-    updateOperator[estateId] = operator;
-    emit UpdateOperator(estateId, operator);
-  }
-
   function isUpdateAuthorized(address operator, uint256 estateId) external view returns (bool) {
     return _isUpdateAuthorized(operator, estateId);
+  }
+
+  function setUpdateOperator(uint256 estateId, address operator) public canTransfer(estateId) {
+    updateOperator[estateId] = operator;
+    emit UpdateOperator(estateId, operator);
   }
 
   function initialize(
@@ -283,6 +283,37 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     for (uint i = 0; i < length; i++) {
       _updateLandData(estateId, landIds[i], data);
     }
+  }
+
+  function transferFrom(address _from, address _to, uint256 _tokenId) 
+  public 
+  {
+    setUpdateOperator(_tokenId, address(0));
+    super.transferFrom(_from, _to, _tokenId);
+  }
+
+  function safeTransferFrom(address _from, address _to, uint256 _tokenId) 
+  public 
+  {
+    setUpdateOperator(_tokenId, address(0));
+    super.safeTransferFrom(_from, _to, _tokenId);
+  }
+
+  function safeTransferFrom(
+    address _from,
+    address _to,
+    uint256 _tokenId,
+    bytes _data
+  )
+  public
+  {
+    setUpdateOperator(_tokenId, address(0));
+    super.safeTransferFrom(
+      _from, 
+      _to,
+      _tokenId, 
+      _data
+    );
   }
 
   // check the supported interfaces via ERC165

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -374,7 +374,6 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     string data
   )
     external
-    // onlyUpdateAuthorized(_encodeTokenId(x, y))
   {
     return _updateLandData(x, y, data);
   }

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -45,7 +45,9 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   modifier onlyUpdateAuthorized(uint256 tokenId) {
     require(
-      msg.sender == _ownerOf(tokenId) || _isUpdateAuthorized(msg.sender, tokenId),
+      msg.sender == _ownerOf(tokenId) || 
+      _isAuthorized(msg.sender, tokenId) ||
+      _isUpdateAuthorized(msg.sender, tokenId),
       "msg.sender is not authorized to update"
     );
     _;
@@ -372,7 +374,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     string data
   )
     external
-    onlyUpdateAuthorized(_encodeTokenId(x, y))
+    // onlyUpdateAuthorized(_encodeTokenId(x, y))
   {
     return _updateLandData(x, y, data);
   }

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1155,13 +1155,13 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     return estateData[estateId];
   }
 
-  function setUpdateOperator(uint256 estateId, address operator) external canTransfer(estateId) {
-    updateOperator[estateId] = operator;
-    emit UpdateOperator(estateId, operator);
-  }
-
   function isUpdateAuthorized(address operator, uint256 estateId) external view returns (bool) {
     return _isUpdateAuthorized(operator, estateId);
+  }
+
+  function setUpdateOperator(uint256 estateId, address operator) public canTransfer(estateId) {
+    updateOperator[estateId] = operator;
+    emit UpdateOperator(estateId, operator);
   }
 
   function initialize(
@@ -1299,6 +1299,37 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     for (uint i = 0; i < length; i++) {
       _updateLandData(estateId, landIds[i], data);
     }
+  }
+
+  function transferFrom(address _from, address _to, uint256 _tokenId) 
+  public 
+  {
+    setUpdateOperator(_tokenId, address(0));
+    super.transferFrom(_from, _to, _tokenId);
+  }
+
+  function safeTransferFrom(address _from, address _to, uint256 _tokenId) 
+  public 
+  {
+    setUpdateOperator(_tokenId, address(0));
+    super.safeTransferFrom(_from, _to, _tokenId);
+  }
+
+  function safeTransferFrom(
+    address _from,
+    address _to,
+    uint256 _tokenId,
+    bytes _data
+  )
+  public
+  {
+    setUpdateOperator(_tokenId, address(0));
+    super.safeTransferFrom(
+      _from, 
+      _to,
+      _tokenId, 
+      _data
+    );
   }
 
   // check the supported interfaces via ERC165

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -909,7 +909,9 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   modifier onlyUpdateAuthorized(uint256 tokenId) {
     require(
-      msg.sender == _ownerOf(tokenId) || _isUpdateAuthorized(msg.sender, tokenId),
+      msg.sender == _ownerOf(tokenId) || 
+      _isAuthorized(msg.sender, tokenId) ||
+      _isUpdateAuthorized(msg.sender, tokenId),
       "msg.sender is not authorized to update"
     );
     _;
@@ -1236,7 +1238,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     string data
   )
     external
-    onlyUpdateAuthorized(_encodeTokenId(x, y))
+    // onlyUpdateAuthorized(_encodeTokenId(x, y))
   {
     return _updateLandData(x, y, data);
   }

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -1238,7 +1238,6 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     string data
   )
     external
-    // onlyUpdateAuthorized(_encodeTokenId(x, y))
   {
     return _updateLandData(x, y, data);
   }

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -308,9 +308,30 @@ contract('EstateRegistry', accounts => {
   })
 
   describe('update metadata and update operator', function() {
-    it('update works correctly', async function() {
+    it('update works correctly :: holder', async function() {
       const estateId = await createUserEstateWithToken1()
       await estate.updateMetadata(estateId, newMetadata, sentByUser)
+      await assertMetadata(estateId, newMetadata)
+    })
+
+    it('update works correctly :: updateOperator', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
+      await estate.updateMetadata(estateId, newMetadata, sentByAnotherUser)
+      await assertMetadata(estateId, newMetadata)
+    })
+
+    it('update works correctly :: operator', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await estate.approve(anotherUser, estateId, sentByUser)
+      await estate.updateMetadata(estateId, newMetadata, sentByAnotherUser)
+      await assertMetadata(estateId, newMetadata)
+    })
+
+    it('update works correctly :: approved for all', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await estate.setApprovalForAll(anotherUser, true, sentByUser)
+      await estate.updateMetadata(estateId, newMetadata, sentByAnotherUser)
       await assertMetadata(estateId, newMetadata)
     })
 
@@ -803,6 +824,32 @@ contract('EstateRegistry', accounts => {
     it('should not support not defined interface', async function() {
       const isSupported = await estate.supportsInterface('123456')
       expect(isSupported).be.false
+    })
+  })
+
+  describe('Update Operator', function() {
+    it('should clean update operator after transfer the Estate :: safeTransferFrom', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
+      let updateOperator = await estate.updateOperator(estateId, sentByUser)
+      expect(updateOperator).be.equal(anotherUser)
+      await estate.safeTransferFrom(user, anotherUser, estateId, sentByUser)
+      updateOperator = await estate.updateOperator(estateId, sentByUser)
+      expect(updateOperator).be.equal(
+        '0x0000000000000000000000000000000000000000'
+      )
+    })
+
+    it('should clean update operator after transfer the Estate :: transferFrom', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
+      let updateOperator = await estate.updateOperator(estateId, sentByUser)
+      expect(updateOperator).be.equal(anotherUser)
+      await estate.transferFrom(user, anotherUser, estateId, sentByUser)
+      updateOperator = await estate.updateOperator(estateId, sentByUser)
+      expect(updateOperator).be.equal(
+        '0x0000000000000000000000000000000000000000'
+      )
     })
   })
 })

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -316,11 +316,29 @@ contract('LANDRegistry', accounts => {
     })
 
     describe('updateLandData', function() {
-      it('updates the parcel data if authorized', async function() {
-        await land.setUpdateOperator(1, user, sentByUser)
+      it('updates the parcel data if authorized :: operator', async function() {
+        await land.approve(operator, 1, sentByUser)
         const originalData = await land.landData(0, 1, sentByUser)
         originalData.should.be.equal('')
-        await land.updateLandData(0, 1, 'test_data', sentByUser)
+        await land.updateLandData(0, 1, 'test_data', sentByOperator)
+        const data = await land.landData(0, 1, sentByUser)
+        data.should.be.equal('test_data')
+      })
+
+      it('updates the parcel data if authorized :: approve for all', async function() {
+        await land.setApprovalForAll(operator, true, sentByUser)
+        const originalData = await land.landData(0, 1, sentByUser)
+        originalData.should.be.equal('')
+        await land.updateLandData(0, 1, 'test_data', sentByOperator)
+        const data = await land.landData(0, 1, sentByUser)
+        data.should.be.equal('test_data')
+      })
+
+      it('updates the parcel data if authorized :: update operator', async function() {
+        await land.setUpdateOperator(1, operator, sentByUser)
+        const originalData = await land.landData(0, 1, sentByUser)
+        originalData.should.be.equal('')
+        await land.updateLandData(0, 1, 'test_data', sentByOperator)
         const data = await land.landData(0, 1, sentByUser)
         data.should.be.equal('test_data')
       })


### PR DESCRIPTION
Depends on #126

- Allow operator and `approvedForAll` to update LAND data
- Change `setUpdateOperator` visibility from `external` to` public` and  and clean the `updateOperator` when transferring an estate
