### PR TITLE
fix: updateOperator event emission

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -292,30 +292,6 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     super.transferFrom(_from, _to, _tokenId);
   }
 
-  function safeTransferFrom(address _from, address _to, uint256 _tokenId) 
-  public 
-  {
-    setUpdateOperator(_tokenId, address(0));
-    super.safeTransferFrom(_from, _to, _tokenId);
-  }
-
-  function safeTransferFrom(
-    address _from,
-    address _to,
-    uint256 _tokenId,
-    bytes _data
-  )
-  public
-  {
-    setUpdateOperator(_tokenId, address(0));
-    super.safeTransferFrom(
-      _from, 
-      _to,
-      _tokenId, 
-      _data
-    );
-  }
-
   // check the supported interfaces via ERC165
   function _supportsInterface(bytes4 _interfaceId) internal view returns (bool) {
     // solium-disable-next-line operator-whitespace

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1308,30 +1308,6 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     super.transferFrom(_from, _to, _tokenId);
   }
 
-  function safeTransferFrom(address _from, address _to, uint256 _tokenId) 
-  public 
-  {
-    setUpdateOperator(_tokenId, address(0));
-    super.safeTransferFrom(_from, _to, _tokenId);
-  }
-
-  function safeTransferFrom(
-    address _from,
-    address _to,
-    uint256 _tokenId,
-    bytes _data
-  )
-  public
-  {
-    setUpdateOperator(_tokenId, address(0));
-    super.safeTransferFrom(
-      _from, 
-      _to,
-      _tokenId, 
-      _data
-    );
-  }
-
   // check the supported interfaces via ERC165
   function _supportsInterface(bytes4 _interfaceId) internal view returns (bool) {
     // solium-disable-next-line operator-whitespace

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -834,6 +834,28 @@ contract('EstateRegistry', accounts => {
       let updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(anotherUser)
       await estate.safeTransferFrom(user, anotherUser, estateId, sentByUser)
+      let logs = await getEstateEvents('UpdateOperator')
+      expect(logs.length).be.equal(1)
+      updateOperator = await estate.updateOperator(estateId, sentByUser)
+      expect(updateOperator).be.equal(
+        '0x0000000000000000000000000000000000000000'
+      )
+    })
+
+    it('should clean update operator after transfer the Estate :: safeTransferFrom with bytes', async function() {
+      const estateId = await createUserEstateWithToken1()
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
+      let updateOperator = await estate.updateOperator(estateId, sentByUser)
+      expect(updateOperator).be.equal(anotherUser)
+      await estate.safeTransferFromWithBytes(
+        user,
+        anotherUser,
+        estateId,
+        '0x',
+        sentByUser
+      )
+      let logs = await getEstateEvents('UpdateOperator')
+      expect(logs.length).be.equal(1)
       updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(
         '0x0000000000000000000000000000000000000000'
@@ -846,6 +868,8 @@ contract('EstateRegistry', accounts => {
       let updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(anotherUser)
       await estate.transferFrom(user, anotherUser, estateId, sentByUser)
+      let logs = await getEstateEvents('UpdateOperator')
+      expect(logs.length).be.equal(1)
       updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(
         '0x0000000000000000000000000000000000000000'

--- a/test/EstateRegistryTest.sol
+++ b/test/EstateRegistryTest.sol
@@ -28,4 +28,20 @@ contract EstateRegistryTest is EstateRegistry {
   function compoundXor(bytes32 x, uint256 y) public pure returns (bytes32) {
     return x ^ keccak256(abi.encodePacked(y));
   }
+
+  function safeTransferFromWithBytes(
+    address from, 
+    address to, 
+    uint256 assetId, 
+    bytes data
+  ) 
+    public 
+  {
+    safeTransferFrom(
+      from, 
+      to,
+      assetId, 
+      data
+    );
+  }
 }


### PR DESCRIPTION
With the new update related to clean the `updateOperator` we are emitting the `UpdateOperator` event three times if the user uses `safeTransferFrom(address, address, uint256)` or twice if uses `safeTransferFrom(address, address, uint256, bytes)`.

There is not bug either vulnerability. It is just consuming more gas and therefore the transactions increased the price.

