### PR TITLE
feat: save gas removing updateOperator event

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -288,7 +288,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   function transferFrom(address _from, address _to, uint256 _tokenId) 
   public 
   {
-    setUpdateOperator(_tokenId, address(0));
+    updateOperator[_tokenId] = address(0);
     super.transferFrom(_from, _to, _tokenId);
   }
 

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1304,7 +1304,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   function transferFrom(address _from, address _to, uint256 _tokenId) 
   public 
   {
-    setUpdateOperator(_tokenId, address(0));
+    updateOperator[_tokenId] = address(0);
     super.transferFrom(_from, _to, _tokenId);
   }
 

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -835,7 +835,7 @@ contract('EstateRegistry', accounts => {
       expect(updateOperator).be.equal(anotherUser)
       await estate.safeTransferFrom(user, anotherUser, estateId, sentByUser)
       let logs = await getEstateEvents('UpdateOperator')
-      expect(logs.length).be.equal(1)
+      expect(logs.length).be.equal(0)
       updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(
         '0x0000000000000000000000000000000000000000'
@@ -855,7 +855,7 @@ contract('EstateRegistry', accounts => {
         sentByUser
       )
       let logs = await getEstateEvents('UpdateOperator')
-      expect(logs.length).be.equal(1)
+      expect(logs.length).be.equal(0)
       updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(
         '0x0000000000000000000000000000000000000000'
@@ -869,7 +869,7 @@ contract('EstateRegistry', accounts => {
       expect(updateOperator).be.equal(anotherUser)
       await estate.transferFrom(user, anotherUser, estateId, sentByUser)
       let logs = await getEstateEvents('UpdateOperator')
-      expect(logs.length).be.equal(1)
+      expect(logs.length).be.equal(0)
       updateOperator = await estate.updateOperator(estateId, sentByUser)
       expect(updateOperator).be.equal(
         '0x0000000000000000000000000000000000000000'


### PR DESCRIPTION
The NFT token standard doesn't emit a clear operator event when a transfer happened.

I think that we should have the same silent behavior when clearing the `updateOperator` on transfer.

At [LANDRegistry](https://github.com/decentraland/land/blob/master/contracts/land/LANDRegistry.sol#L419) we have the same as the NFT token standard with the `operator` and `updateOperator` 

Cleaning the `operator` and `updateOperator` is an action that someone can infer when a transfer occurs.

Also, it saves more gas.