### PR TITLE
Feat: add update operator for all

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -158,7 +158,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     require(_operator != msg.sender, "The operator should be different from owner");
     require(
       _owner == msg.sender ||
-      operatorApprovals[msg.sender][_operator],
+      operatorApprovals[_owner][msg.sender],
       "Unauthorized user"
     );
 

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -157,8 +157,8 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   function setUpdateOperatorForAll(address _owner, address _operator, bool _approved) external {
     require(_operator != msg.sender, "The operator should be different from owner");
     require(
-      _owner == msg.sender ||
-      operatorApprovals[_owner][msg.sender],
+      _owner == msg.sender
+      || operatorApprovals[_owner][msg.sender],
       "Unauthorized user"
     );
 
@@ -336,9 +336,9 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   // check the supported interfaces via ERC165
   function _supportsInterface(bytes4 _interfaceId) internal view returns (bool) {
     // solium-disable-next-line operator-whitespace
-    return super._supportsInterface(_interfaceId) ||
-      _interfaceId == InterfaceId_GetMetadata ||
-      _interfaceId == InterfaceId_VerifyFingerprint;
+    return super._supportsInterface(_interfaceId)
+      || _interfaceId == InterfaceId_GetMetadata
+      || _interfaceId == InterfaceId_VerifyFingerprint;
   }
 
   /**
@@ -459,8 +459,9 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   function _isUpdateAuthorized(address operator, uint256 estateId) internal view returns (bool) {
     address owner = ownerOf(estateId);
 
-    return isApprovedOrOwner(operator, estateId) || updateOperator[estateId] == operator ||
-      updateOperatorForAll[owner][operator];
+    return isApprovedOrOwner(operator, estateId)
+      || updateOperator[estateId] == operator
+      || updateOperatorForAll[owner][operator];
   }
 
   function _isLandUpdateAuthorized(

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -34,4 +34,8 @@ contract EstateStorage {
 
   // Operator of the Estate
   mapping (uint256 => address) public updateOperator;
+
+  // From account to mapping of operator to bool whether is allowed to update content or not
+  mapping(address => mapping(address => bool)) public updateOperatorForAll;
+
 }

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -36,6 +36,6 @@ contract EstateStorage {
   mapping (uint256 => address) public updateOperator;
 
   // From account to mapping of operator to bool whether is allowed to update content or not
-  mapping(address => mapping(address => bool)) public updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateManager;
 
 }

--- a/contracts/estate/IEstateRegistry.sol
+++ b/contracts/estate/IEstateRegistry.sol
@@ -36,7 +36,7 @@ contract IEstateRegistry {
     address indexed _operator
   );
 
-  event UpdateOperatorForAll(
+  event UpdateManager(
     address indexed _owner,
     address indexed _operator,
     address indexed _caller,

--- a/contracts/estate/IEstateRegistry.sol
+++ b/contracts/estate/IEstateRegistry.sol
@@ -36,6 +36,13 @@ contract IEstateRegistry {
     address indexed _operator
   );
 
+  event UpdateOperatorForAll(
+    address indexed _owner,
+    address indexed _operator,
+    address indexed _caller,
+    bool _approved
+  );
+
   event SetLANDRegistry(
     address indexed _registry
   );

--- a/contracts/land/ILANDRegistry.sol
+++ b/contracts/land/ILANDRegistry.sol
@@ -26,7 +26,7 @@ interface ILANDRegistry {
   function updateLandData(int x, int y, string data) external;
   function updateManyLandData(int[] x, int[] y, string data) external;
 
-  // Authorize an updateManager to update data on any parcel
+  // Authorize an updateManager to manage parcel data
   function setUpdateManager(address _owner, address _operator, bool _approved) external;
 
   // Events

--- a/contracts/land/ILANDRegistry.sol
+++ b/contracts/land/ILANDRegistry.sol
@@ -26,8 +26,8 @@ interface ILANDRegistry {
   function updateLandData(int x, int y, string data) external;
   function updateManyLandData(int[] x, int[] y, string data) external;
 
-  // Authorize an updateOperatorForAll to update data on any parcel
-  function setUpdateOperatorForAll(address _owner, address _operator, bool _approved) external;
+  // Authorize an updateManager to update data on any parcel
+  function setUpdateManager(address _owner, address _operator, bool _approved) external;
 
   // Events
 
@@ -43,7 +43,7 @@ interface ILANDRegistry {
     address indexed operator
   );
 
-  event UpdateOperatorForAll(
+  event UpdateManager(
     address indexed _owner,
     address indexed _operator,
     address indexed _caller,

--- a/contracts/land/ILANDRegistry.sol
+++ b/contracts/land/ILANDRegistry.sol
@@ -26,6 +26,9 @@ interface ILANDRegistry {
   function updateLandData(int x, int y, string data) external;
   function updateManyLandData(int[] x, int[] y, string data) external;
 
+  // Authorize an updateOperatorForAll to update data on any parcel
+  function setUpdateOperatorForAll(address _owner, address _operator, bool _approved) external;
+
   // Events
 
   event Update(
@@ -38,6 +41,13 @@ interface ILANDRegistry {
   event UpdateOperator(
     uint256 indexed assetId,
     address indexed operator
+  );
+
+  event UpdateOperatorForAll(
+    address indexed _owner,
+    address indexed _operator,
+    address indexed _caller,
+    bool _approved
   );
 
   event DeployAuthorized(

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -62,7 +62,11 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   }
 
   function _isUpdateAuthorized(address operator, uint256 assetId) internal view returns (bool) {
-    return operator == _ownerOf(assetId) || updateOperator[assetId] == operator;
+    address owner = _ownerOf(assetId);
+
+    return owner == operator  || 
+      updateOperator[assetId] == operator ||
+      updateOperatorForAll[owner][operator];
   }
 
   function authorizeDeploy(address beneficiary) external onlyProxyOwner {
@@ -298,6 +302,30 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     updateOperator[assetId] = operator;
     emit UpdateOperator(assetId, operator);
   }
+
+  /**
+  * @dev Set an updateOperatorForAll for an account
+  * @param _owner - address of the account to set the updateOperatorForAll
+  * @param _operator - address of the account to be set as the updateOperatorForAll
+  * @param _approved - bool whether the address will be approved or not
+  */
+  function setUpdateOperatorForAll(address _owner, address _operator, bool _approved) external {
+    require(_operator != msg.sender, "The operator should be different from owner");
+    require(
+      _owner == msg.sender ||
+      _isApprovedForAll(_owner, msg.sender),
+      "Unauthorized user"
+    );
+
+    updateOperatorForAll[_owner][_operator] = _approved;
+
+    emit UpdateOperatorForAll(
+      _owner, 
+      _operator,
+      msg.sender,
+      _approved
+    );
+  } 
 
   //
   // Estate generation

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -32,7 +32,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   modifier onlyDeployer() {
     require(
-      msg.sender == proxyOwner || authorizedDeploy[msg.sender], 
+      msg.sender == proxyOwner || authorizedDeploy[msg.sender],
       "This function can only be called by an authorized deployer"
     );
     _;
@@ -48,7 +48,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   modifier onlyUpdateAuthorized(uint256 tokenId) {
     require(
-      msg.sender == _ownerOf(tokenId) || 
+      msg.sender == _ownerOf(tokenId) ||
       _isAuthorized(msg.sender, tokenId) ||
       _isUpdateAuthorized(msg.sender, tokenId),
       "msg.sender is not authorized to update"
@@ -56,10 +56,10 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     _;
   }
 
-  modifier onlyManager(uint256 tokenId) {
+  modifier canSetUpdateOperator(uint256 tokenId) {
     address owner = _ownerOf(tokenId);
     require(
-      _isAuthorized(msg.sender, tokenId) || updateManager[owner][msg.sender], 
+      _isAuthorized(msg.sender, tokenId) || updateManager[owner][msg.sender],
       "unauthorized user"
     );
     _;
@@ -76,7 +76,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   function _isUpdateAuthorized(address operator, uint256 assetId) internal view returns (bool) {
     address owner = _ownerOf(assetId);
 
-    return owner == operator  || 
+    return owner == operator  ||
       updateOperator[assetId] == operator ||
       updateManager[owner][operator];
   }
@@ -92,7 +92,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   function forbidDeploy(address beneficiary) external onlyProxyOwner {
     require(beneficiary != address(0), "invalid address");
     require(authorizedDeploy[beneficiary], "address is already forbidden");
-    
+
     authorizedDeploy[beneficiary] = false;
     emit DeployForbidden(msg.sender, beneficiary);
   }
@@ -310,7 +310,13 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     }
   }
 
-  function setUpdateOperator(uint256 assetId, address operator) external onlyManager(assetId) {
+  function setUpdateOperator(
+    uint256 assetId,
+    address operator
+  )
+    external
+    canSetUpdateOperator(assetId)
+  {
     updateOperator[assetId] = operator;
     emit UpdateOperator(assetId, operator);
   }
@@ -332,12 +338,12 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     updateManager[_owner][_operator] = _approved;
 
     emit UpdateManager(
-      _owner, 
+      _owner,
       _operator,
       msg.sender,
       _approved
     );
-  } 
+  }
 
   //
   // Estate generation

--- a/contracts/land/LANDStorage.sol
+++ b/contracts/land/LANDStorage.sol
@@ -18,5 +18,5 @@ contract LANDStorage {
 
   mapping (address => bool) public authorizedDeploy;
 
-  mapping(address => mapping(address => bool)) public updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateManager;
 }

--- a/contracts/land/LANDStorage.sol
+++ b/contracts/land/LANDStorage.sol
@@ -17,4 +17,6 @@ contract LANDStorage {
   IEstateRegistry public estateRegistry;
 
   mapping (address => bool) public authorizedDeploy;
+
+  mapping(address => mapping(address => bool)) public updateOperatorForAll;
 }

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -125,7 +125,7 @@ contract ERC721Receiver {
    * @notice Handle the receipt of an NFT
    * @dev The ERC721 smart contract calls this function on the recipient
    * after a `safetransfer`. This function MAY throw to revert and reject the
-   * transfer. Return of other than the magic value MUST result in the 
+   * transfer. Return of other than the magic value MUST result in the
    * transaction being reverted.
    * Note: the contract address is always the message sender.
    * @param _operator The address which called `safeTransferFrom` function
@@ -237,7 +237,7 @@ contract ERC165Support is ERC165 {
   function supportsInterface(bytes4 _interfaceId)
     external
     view
-    returns (bool) 
+    returns (bool)
   {
     return _supportsInterface(_interfaceId);
   }
@@ -245,7 +245,7 @@ contract ERC165Support is ERC165 {
   function _supportsInterface(bytes4 _interfaceId)
     internal
     view
-    returns (bool) 
+    returns (bool)
   {
     return _interfaceId == InterfaceId_ERC165;
   }
@@ -321,7 +321,7 @@ contract ERC721BasicToken is ERC165Support, ERC721Basic {
     view
     returns (bool)
   {
-    return super._supportsInterface(_interfaceId) || 
+    return super._supportsInterface(_interfaceId) ||
       _interfaceId == InterfaceId_ERC721 || _interfaceId == InterfaceId_ERC721Exists;
   }
 
@@ -751,7 +751,7 @@ contract ERC721Token is Migratable, ERC165Support, ERC721BasicToken, ERC721 {
     view
     returns (bool)
   {
-    return super._supportsInterface(_interfaceId) || 
+    return super._supportsInterface(_interfaceId) ||
       _interfaceId == InterfaceId_ERC721Enumerable || _interfaceId == InterfaceId_ERC721Metadata;
   }
 
@@ -1194,24 +1194,24 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     updateOperatorForAll[_owner][_operator] = _approved;
 
     emit UpdateOperatorForAll(
-      _owner, 
+      _owner,
       _operator,
       msg.sender,
       _approved
     );
-  } 
+  }
 
   function setUpdateOperator(uint256 estateId, address operator) public canTransfer(estateId) {
     updateOperator[estateId] = operator;
     emit UpdateOperator(estateId, operator);
-  }  
+  }
 
   function setLandUpdateOperator(
-    uint256 estateId, 
-    uint256 landId, 
+    uint256 estateId,
+    uint256 landId,
     address operator
-  ) 
-    public 
+  )
+    public
     canTransfer(estateId)
   {
     require(landIdEstate[landId] == estateId, "The LAND is not part of the Estate");
@@ -1355,8 +1355,8 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     }
   }
 
-  function transferFrom(address _from, address _to, uint256 _tokenId) 
-  public 
+  function transferFrom(address _from, address _to, uint256 _tokenId)
+  public
   {
     updateOperator[_tokenId] = address(0);
     super.transferFrom(_from, _to, _tokenId);
@@ -1493,11 +1493,11 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   function _isLandUpdateAuthorized(
-    address operator, 
-    uint256 estateId, 
+    address operator,
+    uint256 estateId,
     uint256 landId
-  ) 
-    internal returns (bool) 
+  )
+    internal returns (bool)
   {
     return _isUpdateAuthorized(operator, estateId) || registry.updateOperator(landId) == operator;
   }

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1033,7 +1033,7 @@ contract EstateStorage {
   mapping (uint256 => address) public updateOperator;
 
   // From account to mapping of operator to bool whether is allowed to update content or not
-  mapping(address => mapping(address => bool)) internal updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateOperatorForAll;
 
 }
 
@@ -1187,7 +1187,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     require(_operator != msg.sender, "The operator should be different from owner");
     require(
       _owner == msg.sender ||
-      operatorApprovals[msg.sender][_operator],
+      operatorApprovals[_owner][msg.sender],
       "Unauthorized user"
     );
 
@@ -1486,7 +1486,10 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   function _isUpdateAuthorized(address operator, uint256 estateId) internal view returns (bool) {
-    return isApprovedOrOwner(operator, estateId) || updateOperator[estateId] == operator;
+    address owner = ownerOf(estateId);
+
+    return isApprovedOrOwner(operator, estateId) || updateOperator[estateId] == operator ||
+      updateOperatorForAll[owner][operator];
   }
 
   function _isLandUpdateAuthorized(

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1068,7 +1068,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     _;
   }
 
-  modifier onlyManager(uint256 estateId) {
+  modifier canSetUpdateOperator(uint256 estateId) {
     address owner = ownerOf(estateId);
     require(
       isApprovedOrOwner(msg.sender, estateId) || updateManager[owner][msg.sender], 
@@ -1210,7 +1210,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     );
   } 
 
-  function setUpdateOperator(uint256 estateId, address operator) public onlyManager(estateId) {
+  function setUpdateOperator(uint256 estateId, address operator) public canSetUpdateOperator(estateId) {
     updateOperator[estateId] = operator;
     emit UpdateOperator(estateId, operator);
   }  
@@ -1221,7 +1221,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     address operator
   ) 
     public 
-    onlyManager(estateId)
+    canSetUpdateOperator(estateId)
   {
     require(landIdEstate[landId] == estateId, "The LAND is not part of the Estate");
     registry.setUpdateOperator(landId, operator);

--- a/full/LANDProxy.sol
+++ b/full/LANDProxy.sol
@@ -105,7 +105,7 @@ contract IEstateRegistry {
     address indexed _operator
   );
 
-  event UpdateOperatorForAll(
+  event UpdateManager(
     address indexed _owner,
     address indexed _operator,
     address indexed _caller,
@@ -134,7 +134,7 @@ contract LANDStorage {
 
   mapping (address => bool) public authorizedDeploy;
 
-  mapping(address => mapping(address => bool)) public updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateManager;
 }
 
 // File: contracts/Storage.sol

--- a/full/LANDProxy.sol
+++ b/full/LANDProxy.sol
@@ -105,6 +105,13 @@ contract IEstateRegistry {
     address indexed _operator
   );
 
+  event UpdateOperatorForAll(
+    address indexed _owner,
+    address indexed _operator,
+    address indexed _caller,
+    bool _approved
+  );
+
   event SetLANDRegistry(
     address indexed _registry
   );
@@ -126,6 +133,8 @@ contract LANDStorage {
   IEstateRegistry public estateRegistry;
 
   mapping (address => bool) public authorizedDeploy;
+
+  mapping(address => mapping(address => bool)) internal updateOperatorForAll;
 }
 
 // File: contracts/Storage.sol

--- a/full/LANDProxy.sol
+++ b/full/LANDProxy.sol
@@ -134,7 +134,7 @@ contract LANDStorage {
 
   mapping (address => bool) public authorizedDeploy;
 
-  mapping(address => mapping(address => bool)) internal updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateOperatorForAll;
 }
 
 // File: contracts/Storage.sol

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -867,7 +867,7 @@ interface ILANDRegistry {
   function updateLandData(int x, int y, string data) external;
   function updateManyLandData(int[] x, int[] y, string data) external;
 
-  // Authorize an updateManager to update data on any parcel
+  // Authorize an updateManager to manage parcel data
   function setUpdateManager(address _owner, address _operator, bool _approved) external;
 
   // Events
@@ -951,7 +951,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     _;
   }
 
-  modifier onlyManager(uint256 tokenId) {
+  modifier canSetUpdateOperator(uint256 tokenId) {
     address owner = _ownerOf(tokenId);
     require(
       _isAuthorized(msg.sender, tokenId) || updateManager[owner][msg.sender], 
@@ -1205,7 +1205,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     }
   }
 
-  function setUpdateOperator(uint256 assetId, address operator) external onlyManager(assetId) {
+  function setUpdateOperator(uint256 assetId, address operator) external canSetUpdateOperator(assetId) {
     updateOperator[assetId] = operator;
     emit UpdateOperator(assetId, operator);
   }

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -134,7 +134,7 @@ contract LANDStorage {
 
   mapping (address => bool) public authorizedDeploy;
 
-  mapping(address => mapping(address => bool)) internal updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateOperatorForAll;
 }
 
 // File: contracts/Storage.sol
@@ -961,7 +961,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
     return owner == operator  || 
       updateOperator[assetId] == operator ||
-      updateOperatorForAll[owner] == operator;
+      updateOperatorForAll[owner][operator];
   }
 
   function authorizeDeploy(address beneficiary) external onlyProxyOwner {

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -105,7 +105,7 @@ contract IEstateRegistry {
     address indexed _operator
   );
 
-  event UpdateOperatorForAll(
+  event UpdateManager(
     address indexed _owner,
     address indexed _operator,
     address indexed _caller,
@@ -134,7 +134,7 @@ contract LANDStorage {
 
   mapping (address => bool) public authorizedDeploy;
 
-  mapping(address => mapping(address => bool)) public updateOperatorForAll;
+  mapping(address => mapping(address => bool)) public updateManager;
 }
 
 // File: contracts/Storage.sol
@@ -867,8 +867,8 @@ interface ILANDRegistry {
   function updateLandData(int x, int y, string data) external;
   function updateManyLandData(int[] x, int[] y, string data) external;
 
-  // Authorize an updateOperatorForAll to update data on any parcel
-  function setUpdateOperatorForAll(address _owner, address _operator, bool _approved) external;
+  // Authorize an updateManager to update data on any parcel
+  function setUpdateManager(address _owner, address _operator, bool _approved) external;
 
   // Events
 
@@ -884,7 +884,7 @@ interface ILANDRegistry {
     address indexed operator
   );
 
-  event UpdateOperatorForAll(
+  event UpdateManager(
     address indexed _owner,
     address indexed _operator,
     address indexed _caller,
@@ -926,7 +926,10 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   }
 
   modifier onlyDeployer() {
-    require(msg.sender == proxyOwner || authorizedDeploy[msg.sender], "This function can only be called by an authorized deployer");
+    require(
+      msg.sender == proxyOwner || authorizedDeploy[msg.sender], 
+      "This function can only be called by an authorized deployer"
+    );
     _;
   }
 
@@ -948,6 +951,15 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     _;
   }
 
+  modifier onlyManager(uint256 tokenId) {
+    address owner = _ownerOf(tokenId);
+    require(
+      _isAuthorized(msg.sender, tokenId) || updateManager[owner][msg.sender], 
+      "unauthorized user"
+    );
+    _;
+  }
+
   //
   // Authorization
   //
@@ -961,7 +973,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
     return owner == operator  || 
       updateOperator[assetId] == operator ||
-      updateOperatorForAll[owner][operator];
+      updateManager[owner][operator];
   }
 
   function authorizeDeploy(address beneficiary) external onlyProxyOwner {
@@ -1193,18 +1205,18 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     }
   }
 
-  function setUpdateOperator(uint256 assetId, address operator) external onlyAuthorized(assetId) {
+  function setUpdateOperator(uint256 assetId, address operator) external onlyManager(assetId) {
     updateOperator[assetId] = operator;
     emit UpdateOperator(assetId, operator);
   }
 
   /**
-  * @dev Set an updateOperatorForAll for an account
-  * @param _owner - address of the account to set the updateOperatorForAll
-  * @param _operator - address of the account to be set as the updateOperatorForAll
+  * @dev Set an updateManager for an account
+  * @param _owner - address of the account to set the updateManager
+  * @param _operator - address of the account to be set as the updateManager
   * @param _approved - bool whether the address will be approved or not
   */
-  function setUpdateOperatorForAll(address _owner, address _operator, bool _approved) external {
+  function setUpdateManager(address _owner, address _operator, bool _approved) external {
     require(_operator != msg.sender, "The operator should be different from owner");
     require(
       _owner == msg.sender ||
@@ -1212,9 +1224,9 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
       "Unauthorized user"
     );
 
-    updateOperatorForAll[_owner][_operator] = _approved;
+    updateManager[_owner][_operator] = _approved;
 
-    emit UpdateOperatorForAll(
+    emit UpdateManager(
       _owner, 
       _operator,
       msg.sender,

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -1205,6 +1205,20 @@ contract('EstateRegistry', accounts => {
       isUpdateOperatorForAll.should.be.equal(true)
     })
 
+    it('clears updateOperatorForAll correctly ', async function() {
+      await assertMetadata(1, '')
+
+      await estate.setUpdateOperatorForAll(user, operator, true, sentByUser)
+
+      await estate.updateMetadata(1, 'newValue', sentByOperator)
+
+      await assertMetadata(1, 'newValue')
+
+      await estate.setUpdateOperatorForAll(user, operator, false, sentByUser)
+
+      await assertRevert(estate.updateMetadata(1, 'again', sentByOperator))
+    })
+
     it('reverts when updateOperatorForAll trying to change content of no owned by the owner Estate', async function() {
       await estate.setUpdateOperatorForAll(user, operator, true, sentByUser)
 

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -1240,12 +1240,26 @@ contract('EstateRegistry', accounts => {
     })
 
     it('reverts if not owner or approvedForAll set updateManager', async function() {
+      // Not owner
       await assertRevert(
         estate.setUpdateManager(user, operator, true, sentByAnotherUser)
       )
 
+      // Hacker
       await assertRevert(
         estate.setUpdateManager(user, operator, true, sentByHacker)
+      )
+
+      // Operator
+      await estate.approve(operator, 1, sentByUser)
+      await assertRevert(
+        estate.setUpdateManager(user, operator, true, sentByOperator)
+      )
+
+      // Update Operator
+      await estate.setUpdateOperator(1, anotherUser, sentByUser)
+      await assertRevert(
+        estate.setUpdateManager(user, operator, true, sentByAnotherUser)
       )
     })
 

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -1021,6 +1021,22 @@ contract('LANDRegistry', accounts => {
       isUpdateOperatorForAll.should.be.equal(true)
     })
 
+    it('clears updateOperatorForAll correctly ', async function() {
+      let data = await land.landData(0, 1)
+      data.should.be.equal('')
+
+      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+
+      await land.updateLandData(0, 1, 'newValue', sentByOperator)
+
+      data = await land.landData(0, 1)
+      data.should.be.equal('newValue')
+
+      await land.setUpdateOperatorForAll(user, operator, false, sentByUser)
+
+      await assertRevert(land.updateLandData(0, 1, 'again', sentByOperator))
+    })
+
     it('reverts when updateOperatorForAll trying to change content of no owned by the owner LAND', async function() {
       await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
 

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -742,6 +742,17 @@ contract('LANDRegistry', accounts => {
       updateOperator.should.be.equal(anotherUser)
     })
 
+    it('should set an update operator by updateManager', async function() {
+      let updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+
+      await land.setUpdateManager(user, operator, true, sentByUser)
+      await land.setUpdateOperator(1, anotherUser, sentByOperator)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
     it('reverts if not owner want to update the update operator', async function() {
       await assertRevert(
         land.setUpdateOperator(1, anotherUser, sentByAnotherUser)
@@ -901,9 +912,9 @@ contract('LANDRegistry', accounts => {
     })
   })
 
-  describe('UpdateOperatorForAll', function() {
-    it('should set updateOperatorForAll by owner', async function() {
-      const { logs } = await land.setUpdateOperatorForAll(
+  describe('UpdateManager', function() {
+    it('should set updateManager by owner', async function() {
+      const { logs } = await land.setUpdateManager(
         user,
         operator,
         true,
@@ -913,27 +924,24 @@ contract('LANDRegistry', accounts => {
       logs.length.should.be.equal(1)
 
       const log = logs[0]
-      log.event.should.be.eq('UpdateOperatorForAll')
+      log.event.should.be.eq('UpdateManager')
       log.args._owner.should.be.bignumber.equal(user)
       log.args._operator.should.be.equal(operator)
       log.args._caller.should.be.equal(user)
       log.args._approved.should.be.equal(true)
 
-      let isUpdateOperatorForAll = await land.updateOperatorForAll(
-        user,
-        operator
-      )
-      isUpdateOperatorForAll.should.be.equal(true)
+      let isUpdateManager = await land.updateManager(user, operator)
+      isUpdateManager.should.be.equal(true)
 
-      await land.setUpdateOperatorForAll(user, operator, false, sentByUser)
-      isUpdateOperatorForAll = await land.updateOperatorForAll(user, operator)
-      isUpdateOperatorForAll.should.be.equal(false)
+      await land.setUpdateManager(user, operator, false, sentByUser)
+      isUpdateManager = await land.updateManager(user, operator)
+      isUpdateManager.should.be.equal(false)
     })
 
-    it('should set updateOperatorForAll by approvedForAll', async function() {
+    it('should set updateManager by approvedForAll', async function() {
       await land.setApprovalForAll(anotherUser, true, sentByUser)
 
-      const { logs } = await land.setUpdateOperatorForAll(
+      const { logs } = await land.setUpdateManager(
         user,
         operator,
         true,
@@ -943,35 +951,27 @@ contract('LANDRegistry', accounts => {
       logs.length.should.be.equal(1)
 
       const log = logs[0]
-      log.event.should.be.eq('UpdateOperatorForAll')
+      log.event.should.be.eq('UpdateManager')
       log.args._owner.should.be.bignumber.equal(user)
       log.args._operator.should.be.equal(operator)
       log.args._caller.should.be.equal(anotherUser)
       log.args._approved.should.be.equal(true)
 
-      let isUpdateOperatorForAll = await land.updateOperatorForAll(
-        user,
-        operator
-      )
-      isUpdateOperatorForAll.should.be.equal(true)
+      let isUpdateManager = await land.updateManager(user, operator)
+      isUpdateManager.should.be.equal(true)
 
-      await land.setUpdateOperatorForAll(
-        user,
-        operator,
-        false,
-        sentByAnotherUser
-      )
-      isUpdateOperatorForAll = await land.updateOperatorForAll(user, operator)
-      isUpdateOperatorForAll.should.be.equal(false)
+      await land.setUpdateManager(user, operator, false, sentByAnotherUser)
+      isUpdateManager = await land.updateManager(user, operator)
+      isUpdateManager.should.be.equal(false)
     })
 
-    it('should allow updateOperatorForAll to update content', async function() {
+    it('should allow updateManager to update content', async function() {
       let data = await land.landData(0, 1)
       data.should.be.equal('')
       data = await land.landData(0, 2)
       data.should.be.equal('')
 
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+      await land.setUpdateManager(user, operator, true, sentByUser)
 
       await land.updateLandData(0, 1, 'newValue', sentByOperator)
       await land.updateLandData(0, 2, 'newValue', sentByOperator)
@@ -982,8 +982,8 @@ contract('LANDRegistry', accounts => {
       data.should.be.equal('newValue')
     })
 
-    it('should allow updateOperatorForAll to update content on new LANDs', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('should allow updateManager to update content on new LANDs', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
 
       await land.assignNewParcel(0, 3, user, sentByCreator)
 
@@ -996,49 +996,40 @@ contract('LANDRegistry', accounts => {
       data.should.be.equal('newValue')
     })
 
-    it('should has false as default value for updateOperatorForAll', async function() {
-      const isUpdateOperatorForAll = await land.updateOperatorForAll(
-        user,
-        operator
-      )
-      isUpdateOperatorForAll.should.be.equal(false)
+    it('should has false as default value for updateManager', async function() {
+      const isUpdateManager = await land.updateManager(user, operator)
+      isUpdateManager.should.be.equal(false)
     })
 
-    it('should set multiple updateOperatorForAll', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
-      await land.setUpdateOperatorForAll(user, anotherUser, true, sentByUser)
+    it('should set multiple updateManager', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
+      await land.setUpdateManager(user, anotherUser, true, sentByUser)
 
-      let isUpdateOperatorForAll = await land.updateOperatorForAll(
-        user,
-        operator
-      )
-      isUpdateOperatorForAll.should.be.equal(true)
+      let isUpdateManager = await land.updateManager(user, operator)
+      isUpdateManager.should.be.equal(true)
 
-      isUpdateOperatorForAll = await land.updateOperatorForAll(
-        user,
-        anotherUser
-      )
-      isUpdateOperatorForAll.should.be.equal(true)
+      isUpdateManager = await land.updateManager(user, anotherUser)
+      isUpdateManager.should.be.equal(true)
     })
 
-    it('clears updateOperatorForAll correctly ', async function() {
+    it('clears updateManager correctly ', async function() {
       let data = await land.landData(0, 1)
       data.should.be.equal('')
 
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+      await land.setUpdateManager(user, operator, true, sentByUser)
 
       await land.updateLandData(0, 1, 'newValue', sentByOperator)
 
       data = await land.landData(0, 1)
       data.should.be.equal('newValue')
 
-      await land.setUpdateOperatorForAll(user, operator, false, sentByUser)
+      await land.setUpdateManager(user, operator, false, sentByUser)
 
       await assertRevert(land.updateLandData(0, 1, 'again', sentByOperator))
     })
 
-    it('reverts when updateOperatorForAll trying to change content of no owned by the owner LAND', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('reverts when updateManager trying to change content of no owned by the owner LAND', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
 
       await land.transferLand(0, 1, anotherUser, sentByUser)
 
@@ -1052,51 +1043,44 @@ contract('LANDRegistry', accounts => {
       await assertRevert(land.updateLandData(0, 1, 'newValue', sentByOperator))
     })
 
-    it('reverts if owner set himself as updateOperatorForAll', async function() {
+    it('reverts if owner set himself as updateManager', async function() {
+      await assertRevert(land.setUpdateManager(user, user, true, sentByUser))
+    })
+
+    it('reverts if not owner or approvedForAll set updateManager', async function() {
       await assertRevert(
-        land.setUpdateOperatorForAll(user, user, true, sentByUser)
+        land.setUpdateManager(user, operator, true, sentByAnotherUser)
+      )
+
+      await assertRevert(
+        land.setUpdateManager(user, operator, true, sentByHacker)
       )
     })
 
-    it('reverts if not owner or approvedForAll set updateOperatorForAll', async function() {
-      await assertRevert(
-        land.setUpdateOperatorForAll(user, operator, true, sentByAnotherUser)
-      )
-
-      await assertRevert(
-        land.setUpdateOperatorForAll(user, operator, true, sentByHacker)
-      )
-    })
-
-    it('reverts when updateOperatorForAll trying to transfer', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('reverts when updateManager trying to transfer', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
       await assertRevert(land.transferLand(0, 1, anotherUser, sentByOperator))
     })
 
-    it('reverts when updateOperatorForAll trying to set updateOperatorForAll', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('reverts when updateManager trying to set updateManager', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
       await assertRevert(
-        land.setUpdateOperatorForAll(user, anotherUser, 1, sentByOperator)
+        land.setUpdateManager(user, anotherUser, 1, sentByOperator)
       )
     })
 
-    it('reverts when updateOperatorForAll trying to set operator', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('reverts when updateManager trying to set operator', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
       await assertRevert(land.approve(anotherUser, 1, sentByOperator))
     })
 
-    it('reverts when updateOperatorForAll trying to set UpdateOperator', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
-      await assertRevert(land.setUpdateOperator(1, anotherUser, sentByOperator))
-    })
-
-    it('reverts when updateOperatorForAll trying to set create an Estate', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('reverts when updateManager trying to set create an Estate', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
       await assertRevert(land.createEstate([0], [1], user, sentByOperator))
     })
 
-    it('reverts when updateOperatorForAll trying to assign LANDs', async function() {
-      await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
+    it('reverts when updateManager trying to assign LANDs', async function() {
+      await land.setUpdateManager(user, operator, true, sentByUser)
       await assertRevert(land.assignNewParcel(0, 3, user, sentByOperator))
     })
   })

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -1048,12 +1048,26 @@ contract('LANDRegistry', accounts => {
     })
 
     it('reverts if not owner or approvedForAll set updateManager', async function() {
+      // Not owner
       await assertRevert(
         land.setUpdateManager(user, operator, true, sentByAnotherUser)
       )
 
+      // Hacker
       await assertRevert(
         land.setUpdateManager(user, operator, true, sentByHacker)
+      )
+
+      // Operator
+      await land.approve(operator, 1, sentByUser)
+      await assertRevert(
+        land.setUpdateManager(user, operator, true, sentByOperator)
+      )
+
+      // Update Operator
+      await land.setUpdateOperator(1, anotherUser, sentByUser)
+      await assertRevert(
+        land.setUpdateManager(user, operator, true, sentByAnotherUser)
       )
     })
 

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -919,11 +919,15 @@ contract('LANDRegistry', accounts => {
       log.args._caller.should.be.equal(user)
       log.args._approved.should.be.equal(true)
 
-      const isUpdateOperatorForAll = await land.updateOperatorForAll(
+      let isUpdateOperatorForAll = await land.updateOperatorForAll(
         user,
         operator
       )
       isUpdateOperatorForAll.should.be.equal(true)
+
+      await land.setUpdateOperatorForAll(user, operator, false, sentByUser)
+      isUpdateOperatorForAll = await land.updateOperatorForAll(user, operator)
+      isUpdateOperatorForAll.should.be.equal(false)
     })
 
     it('should set updateOperatorForAll by approvedForAll', async function() {
@@ -1017,7 +1021,7 @@ contract('LANDRegistry', accounts => {
       isUpdateOperatorForAll.should.be.equal(true)
     })
 
-    it('reverts when updateOperatorForAll trying to change content of no owned by owner LAND', async function() {
+    it('reverts when updateOperatorForAll trying to change content of no owned by the owner LAND', async function() {
       await land.setUpdateOperatorForAll(user, operator, true, sentByUser)
 
       await land.transferLand(0, 1, anotherUser, sentByUser)

--- a/zos.ropsten.json
+++ b/zos.ropsten.json
@@ -1,10 +1,10 @@
 {
   "contracts": {
     "EstateRegistry": {
-      "address": "0xbddeee6d77a53ce6df806be18058313aa31a0a5c",
-      "constructorCode": "608060405234801561001057600080fd5b506141d3806100206000396000f300",
-      "bodyBytecodeHash": "3d5e539b735b87634dfb8a7ee6a6337ef9de7cb5965dc879abb803b79ff72803",
-      "bytecodeHash": "c0057e067c76729affda93fa532727062767798fff2e552f8df531f4a825741d"
+      "address": "0xa3eccab5bd4153267e863936346254fb38211a9d",
+      "constructorCode": "608060405234801561001057600080fd5b50614425806100206000396000f300",
+      "bodyBytecodeHash": "16ad2f943cf89bef825bd04148b8469f9b119de7b384bb563a8811e6094385bc",
+      "bytecodeHash": "83358656de21aa0a5900a8634e84d245c216767fde393917c25bf3dd0e6d9aa5"
     }
   },
   "proxies": {
@@ -12,7 +12,7 @@
       {
         "address": "0x124bf28a423b2ca80b3846c3aa0eb944fe7ebb95",
         "version": "0.1.0",
-        "implementation": "0xbddeee6d77a53ce6df806be18058313aa31a0a5c"
+        "implementation": "0xa3eccab5bd4153267e863936346254fb38211a9d"
       }
     ]
   },


### PR DESCRIPTION
- Add `UpdateOperatorForAll` for LAND and Estate registry smart contracts

Interface:

```javascript
setUpdateManager(address _owner, address _operator, bool _approved)

event UpdateManager(
    address indexed _owner,
    address indexed _operator,
    address indexed _caller,
    bool _approved
); 
```