### PR TITLE
Feat: many update operators

### DIFF
--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -247,8 +247,8 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   {
     for (uint i = 0; i < _landIds.length; i++) {
       require(landIdEstate[_landIds[i]] == _estateId, "The LAND is not part of the Estate");
-      registry.setManyUpdateOperator(_landIds, _operator);
     }
+    registry.setManyUpdateOperator(_landIds, _operator);
   }
 
   function initialize(

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -243,9 +243,11 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     address _operator
   )
     public
+    canSetUpdateOperator(_estateId)
   {
     for (uint i = 0; i < _landIds.length; i++) {
-      setLandUpdateOperator(_estateId, _landIds[i], _operator);
+      require(landIdEstate[_landIds[i]] == _estateId, "The LAND is not part of the Estate");
+      registry.setManyUpdateOperator(_landIds, _operator);
     }
   }
 

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -182,7 +182,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @notice Set estate updateOperator
+   * @notice Set Estate updateOperator
    * @param estateId - Estate id
    * @param operator - address of the account to be set as the updateOperator
    */
@@ -198,7 +198,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @notice Set estates updateOperator
+   * @notice Set Estates updateOperator
    * @param _estateIds - Estate ids
    * @param _operator - address of the account to be set as the updateOperator
    */
@@ -232,7 +232,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
  /**
-   * @notice Set many land updateOperator
+   * @notice Set many LAND updateOperator
    * @param _estateId - Estate id
    * @param _landIds - LANDs to set the updateOperator
    * @param _operator - address of the account to be set as the updateOperator

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -181,6 +181,11 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     );
   }
 
+  /**
+   * @notice Set estate updateOperator
+   * @param estateId - Estate id
+   * @param operator - address of the account to be set as the updateOperator
+   */
   function setUpdateOperator(
     uint256 estateId,
     address operator
@@ -192,6 +197,28 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     emit UpdateOperator(estateId, operator);
   }
 
+  /**
+   * @notice Set estates updateOperator
+   * @param _estateIds - Estate ids
+   * @param _operator - address of the account to be set as the updateOperator
+   */
+  function setManyUpdateOperator(
+    uint256[] _estateIds,
+    address _operator
+  )
+    public
+  {
+    for (uint i = 0; i < _estateIds.length; i++) {
+      setUpdateOperator(_estateIds[i], _operator);
+    }
+  }
+
+  /**
+   * @notice Set many lands updateOperator
+   * @param estateId - Estate id
+   * @param landId - LAND to set the updateOperator
+   * @param operator - address of the account to be set as the updateOperator
+   */
   function setLandUpdateOperator(
     uint256 estateId,
     uint256 landId,
@@ -202,6 +229,24 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   {
     require(landIdEstate[landId] == estateId, "The LAND is not part of the Estate");
     registry.setUpdateOperator(landId, operator);
+  }
+
+ /**
+   * @notice Set many land updateOperator
+   * @param _estateId - Estate id
+   * @param _landIds - LANDs to set the updateOperator
+   * @param _operator - address of the account to be set as the updateOperator
+   */
+  function setManyLandUpdateOperator(
+    uint256 _estateId,
+    uint256[] _landIds,
+    address _operator
+  )
+    public
+  {
+    for (uint i = 0; i < _landIds.length; i++) {
+      setLandUpdateOperator(_estateId, _landIds[i], _operator);
+    }
   }
 
   function initialize(

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -214,7 +214,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @notice Set many lands updateOperator
+   * @notice Set LAND updateOperator
    * @param estateId - Estate id
    * @param landId - LAND to set the updateOperator
    * @param operator - address of the account to be set as the updateOperator

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -5,6 +5,7 @@ contract LANDRegistry {
   function decodeTokenId(uint value) external pure returns (int, int);
   function updateLandData(int x, int y, string data) external;
   function setUpdateOperator(uint256 assetId, address operator) external;
+  function setManyUpdateOperator(uint256[] landIds, address operator) external;
   function ping() public;
   function ownerOf(uint256 tokenId) public returns (address);
   function safeTransferFrom(address, address, uint256) public;

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -310,15 +310,36 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     }
   }
 
+  /**
+   * @notice Set estates updateOperator
+   * @param assetId - LAND id
+   * @param operator - address of the account to be set as the updateOperator
+   */
   function setUpdateOperator(
     uint256 assetId,
     address operator
   )
-    external
+    public
     canSetUpdateOperator(assetId)
   {
     updateOperator[assetId] = operator;
     emit UpdateOperator(assetId, operator);
+  }
+
+  /**
+   * @notice Set estates updateOperator
+   * @param _assetIds - LAND ids
+   * @param _operator - address of the account to be set as the updateOperator
+   */
+  function setManyUpdateOperator(
+    uint256[] _assetIds,
+    address _operator
+  )
+    public
+  {
+    for (uint i = 0; i < _assetIds.length; i++) {
+      setUpdateOperator(_assetIds[i], _operator);
+    }
   }
 
   /**

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -311,7 +311,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   }
 
   /**
-   * @notice Set estates updateOperator
+   * @notice Set LAND updateOperator
    * @param assetId - LAND id
    * @param operator - address of the account to be set as the updateOperator
    */
@@ -327,7 +327,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   }
 
   /**
-   * @notice Set estates updateOperator
+   * @notice Set many LAND updateOperator
    * @param _assetIds - LAND ids
    * @param _operator - address of the account to be set as the updateOperator
    */

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1212,7 +1212,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @notice Set estate updateOperator
+   * @notice Set Estate updateOperator
    * @param estateId - Estate id
    * @param operator - address of the account to be set as the updateOperator
    */
@@ -1228,7 +1228,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @notice Set estates updateOperator
+   * @notice Set Estates updateOperator
    * @param _estateIds - Estate ids
    * @param _operator - address of the account to be set as the updateOperator
    */
@@ -1244,7 +1244,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @notice Set many lands updateOperator
+   * @notice Set LAND updateOperator
    * @param estateId - Estate id
    * @param landId - LAND to set the updateOperator
    * @param operator - address of the account to be set as the updateOperator
@@ -1262,7 +1262,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
  /**
-   * @notice Set many land updateOperator
+   * @notice Set many LAND updateOperator
    * @param _estateId - Estate id
    * @param _landIds - LANDs to set the updateOperator
    * @param _operator - address of the account to be set as the updateOperator

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -1206,7 +1206,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   }
 
   /**
-   * @notice Set estates updateOperator
+   * @notice Set LAND updateOperator
    * @param assetId - LAND id
    * @param operator - address of the account to be set as the updateOperator
    */
@@ -1222,7 +1222,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   }
 
   /**
-   * @notice Set estates updateOperator
+   * @notice Set many LAND updateOperator
    * @param _assetIds - LAND ids
    * @param _operator - address of the account to be set as the updateOperator
    */

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -927,7 +927,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   modifier onlyDeployer() {
     require(
-      msg.sender == proxyOwner || authorizedDeploy[msg.sender], 
+      msg.sender == proxyOwner || authorizedDeploy[msg.sender],
       "This function can only be called by an authorized deployer"
     );
     _;
@@ -943,7 +943,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   modifier onlyUpdateAuthorized(uint256 tokenId) {
     require(
-      msg.sender == _ownerOf(tokenId) || 
+      msg.sender == _ownerOf(tokenId) ||
       _isAuthorized(msg.sender, tokenId) ||
       _isUpdateAuthorized(msg.sender, tokenId),
       "msg.sender is not authorized to update"
@@ -954,7 +954,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   modifier canSetUpdateOperator(uint256 tokenId) {
     address owner = _ownerOf(tokenId);
     require(
-      _isAuthorized(msg.sender, tokenId) || updateManager[owner][msg.sender], 
+      _isAuthorized(msg.sender, tokenId) || updateManager[owner][msg.sender],
       "unauthorized user"
     );
     _;
@@ -971,7 +971,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   function _isUpdateAuthorized(address operator, uint256 assetId) internal view returns (bool) {
     address owner = _ownerOf(assetId);
 
-    return owner == operator  || 
+    return owner == operator  ||
       updateOperator[assetId] == operator ||
       updateManager[owner][operator];
   }
@@ -987,7 +987,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   function forbidDeploy(address beneficiary) external onlyProxyOwner {
     require(beneficiary != address(0), "invalid address");
     require(authorizedDeploy[beneficiary], "address is already forbidden");
-    
+
     authorizedDeploy[beneficiary] = false;
     emit DeployForbidden(msg.sender, beneficiary);
   }
@@ -1205,9 +1205,36 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     }
   }
 
-  function setUpdateOperator(uint256 assetId, address operator) external canSetUpdateOperator(assetId) {
+  /**
+   * @notice Set estates updateOperator
+   * @param assetId - LAND id
+   * @param operator - address of the account to be set as the updateOperator
+   */
+  function setUpdateOperator(
+    uint256 assetId,
+    address operator
+  )
+    public
+    canSetUpdateOperator(assetId)
+  {
     updateOperator[assetId] = operator;
     emit UpdateOperator(assetId, operator);
+  }
+
+  /**
+   * @notice Set estates updateOperator
+   * @param _assetIds - LAND ids
+   * @param _operator - address of the account to be set as the updateOperator
+   */
+  function setManyUpdateOperator(
+    uint256[] _assetIds,
+    address _operator
+  )
+    public
+  {
+    for (uint i = 0; i < _assetIds.length; i++) {
+      setUpdateOperator(_assetIds[i], _operator);
+    }
   }
 
   /**
@@ -1227,12 +1254,12 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     updateManager[_owner][_operator] = _approved;
 
     emit UpdateManager(
-      _owner, 
+      _owner,
       _operator,
       msg.sender,
       _approved
     );
-  } 
+  }
 
   //
   // Estate generation

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -1289,7 +1289,7 @@ contract('EstateRegistry', accounts => {
     })
   })
 
-  describe('Update Many Operators', function() {
+  describe('setManyUpdateOperator', function() {
     let estateId1
     let estateId2
     beforeEach(async function() {
@@ -1425,7 +1425,7 @@ contract('EstateRegistry', accounts => {
     })
   })
 
-  describe('Update Many LAND Update Operator', function() {
+  describe('setManyLandUpdateOperator', function() {
     let estateId
     let updateOperator
     beforeEach(async function() {

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -1288,4 +1288,304 @@ contract('EstateRegistry', accounts => {
       await assertRevert(estate.transferLand(1, 1, anotherUser, sentByOperator))
     })
   })
+
+  describe('Update Many Operators', function() {
+    let estateId1
+    let estateId2
+    beforeEach(async function() {
+      estateId1 = await createUserEstateWithToken1()
+      estateId2 = await createUserEstateWithToken2()
+    })
+
+    it('should set update operator', async function() {
+      let updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+
+      await estate.setManyUpdateOperator([estateId1], operator, sentByUser)
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(operator)
+    })
+
+    it('should set many update operator :: owner', async function() {
+      let updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+
+      await estate.setManyUpdateOperator(
+        [estateId1, estateId2],
+        operator,
+        sentByUser
+      )
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(operator)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(operator)
+    })
+
+    it('should set many update operator :: approvedForAll', async function() {
+      let updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+
+      await estate.setApprovalForAll(anotherUser, true, sentByUser)
+      await estate.setManyUpdateOperator(
+        [estateId1, estateId2],
+        operator,
+        sentByAnotherUser
+      )
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(operator)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(operator)
+    })
+
+    it('should set many update operator :: operator', async function() {
+      let updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+
+      await estate.approve(anotherUser, estateId1, sentByUser)
+      await estate.approve(anotherUser, estateId2, sentByUser)
+
+      await estate.setManyUpdateOperator(
+        [estateId1, estateId2],
+        operator,
+        sentByAnotherUser
+      )
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(operator)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(operator)
+    })
+
+    it('should set many update operator :: updateManager', async function() {
+      let updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+
+      await estate.setUpdateManager(user, anotherUser, true, sentByUser)
+
+      await estate.setManyUpdateOperator(
+        [estateId1, estateId2],
+        operator,
+        sentByAnotherUser
+      )
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(operator)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(operator)
+    })
+
+    it('should clean many update operator', async function() {
+      let updateOperator
+      await estate.setManyUpdateOperator(
+        [estateId1, estateId2],
+        anotherUser,
+        sentByUser
+      )
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(anotherUser)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(anotherUser)
+
+      await estate.setManyUpdateOperator(
+        [estateId1, estateId2],
+        EMPTY_ADDRESS,
+        sentByUser
+      )
+
+      updateOperator = await estate.updateOperator(estateId1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      updateOperator = await estate.updateOperator(estateId2)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+    })
+
+    it('reverts when updateOperator try to set many update operator', async function() {
+      await estate.setUpdateOperator(estateId1, anotherUser, sentByUser)
+
+      await assertRevert(
+        estate.setManyUpdateOperator([estateId1], operator, sentByAnotherUser)
+      )
+    })
+
+    it('reverts when unauthorized user try to set many update operator', async function() {
+      await assertRevert(
+        estate.setManyUpdateOperator([estateId1], operator, sentByAnotherUser)
+      )
+    })
+  })
+
+  describe('Update Many LAND Update Operator', function() {
+    let estateId
+    let updateOperator
+    beforeEach(async function() {
+      estateId = await createUserEstateWithNumberedTokens()
+      updateOperator = EMPTY_ADDRESS
+    })
+
+    it('should set LAND update operator', async function() {
+      updateOperator = await land.updateOperator(1)
+      expect(updateOperator).be.equal(EMPTY_ADDRESS)
+
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        [1],
+        anotherUser,
+        sentByUser
+      )
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
+    it('should set many LAND update operator :: owner', async function() {
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      }
+
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        fiveY,
+        anotherUser,
+        sentByUser
+      )
+
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(anotherUser)
+      }
+    })
+
+    it('should set many LAND update operator :: approvedForAll', async function() {
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      }
+
+      await estate.setApprovalForAll(anotherUser, true, sentByUser)
+
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        fiveY,
+        operator,
+        sentByAnotherUser
+      )
+
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(operator)
+      }
+    })
+
+    it('should set many LAND update operator :: operator', async function() {
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      }
+
+      await estate.approve(anotherUser, estateId, sentByUser)
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        fiveY,
+        operator,
+        sentByAnotherUser
+      )
+
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(operator)
+      }
+    })
+
+    it('should set many LAND update operator :: updateManager', async function() {
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      }
+
+      await estate.setUpdateManager(user, anotherUser, true, sentByUser)
+
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        fiveY,
+        operator,
+        sentByAnotherUser
+      )
+
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(operator)
+      }
+    })
+
+    it('should clean many LAND update operator', async function() {
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        fiveY,
+        anotherUser,
+        sentByUser
+      )
+
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(anotherUser)
+      }
+
+      await estate.setManyLandUpdateOperator(
+        estateId,
+        fiveY,
+        EMPTY_ADDRESS,
+        sentByUser
+      )
+
+      for (let id of fiveY) {
+        updateOperator = await land.updateOperator(id)
+        expect(updateOperator).be.equal(EMPTY_ADDRESS)
+      }
+    })
+
+    it('reverts when updateOperator try to set many LAND update operator', async function() {
+      await estate.setUpdateOperator(estateId, anotherUser, sentByUser)
+
+      await assertRevert(
+        estate.setManyLandUpdateOperator(
+          estateId,
+          fiveY,
+          yetAnotherUser,
+          sentByAnotherUser
+        )
+      )
+    })
+
+    it('reverts when setting LAND updateOperator for a LAND outside the estate', async function() {
+      await land.assignMultipleParcels([0], [6], user, sentByCreator)
+      await createEstate([0], [6], user, sentByUser)
+
+      await assertRevert(
+        estate.setManyLandUpdateOperator(estateId, [6], anotherUser, sentByUser)
+      )
+    })
+
+    it('reverts when unauthorized user try to set many update operator', async function() {
+      await assertRevert(
+        estate.setManyLandUpdateOperator(
+          estateId,
+          fiveY,
+          operator,
+          sentByAnotherUser
+        )
+      )
+    })
+  })
 })

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -1098,4 +1098,112 @@ contract('LANDRegistry', accounts => {
       await assertRevert(land.assignNewParcel(0, 3, user, sentByOperator))
     })
   })
+
+  describe('setManyUpdateOperator', function() {
+    let updateOperator
+
+    it('should set update operator', async function() {
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+
+      await land.setManyUpdateOperator([1], anotherUser, sentByUser)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
+    it('should set many update operator :: owner', async function() {
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(NONE)
+
+      await land.setManyUpdateOperator([1, 2], anotherUser, sentByUser)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
+    it('should set many update operator :: approvedForAll', async function() {
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(NONE)
+
+      await land.setApprovalForAll(operator, true, sentByUser)
+
+      await land.setManyUpdateOperator([1, 2], anotherUser, sentByOperator)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
+    it('should set many update operator :: operator', async function() {
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(NONE)
+
+      await land.approve(operator, 1, sentByUser)
+      await land.approve(operator, 2, sentByUser)
+      await land.setManyUpdateOperator([1, 2], anotherUser, sentByOperator)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
+    it('should set many update operator :: updateManager', async function() {
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(NONE)
+
+      await land.setUpdateManager(user, operator, true, sentByUser)
+      await land.setManyUpdateOperator([1, 2], anotherUser, sentByOperator)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(anotherUser)
+    })
+
+    it('should clean many update operator', async function() {
+      await land.setManyUpdateOperator([1, 2], anotherUser, sentByUser)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(anotherUser)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(anotherUser)
+
+      await land.setManyUpdateOperator([1, 2], NONE, sentByUser)
+
+      updateOperator = await land.updateOperator(1)
+      updateOperator.should.be.equal(NONE)
+      updateOperator = await land.updateOperator(2)
+      updateOperator.should.be.equal(NONE)
+    })
+
+    it('reverts when updateOperator try to set many update operator', async function() {
+      await land.setUpdateOperator(1, anotherUser, sentByUser)
+
+      await assertRevert(
+        land.setManyUpdateOperator([1], operator, sentByAnotherUser)
+      )
+    })
+
+    it('reverts if not owner want to update the update operator', async function() {
+      await assertRevert(
+        land.setManyUpdateOperator([1], anotherUser, sentByAnotherUser)
+      )
+      await assertRevert(
+        land.setManyUpdateOperator([1], anotherUser, sentByHacker)
+      )
+    })
+  })
 })


### PR DESCRIPTION
Set many update operators to Estates and LANDs

EstateRegistry:
- Set many update operators
- Set many LAND update operators (Note that calls `setManyUpdateOperator` from LANDRegistry by checking if the LAND is part of the Estate)

LANDRegistry:
- Set many update operators