### PR TITLE
Feat: land estate balances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 
 .zos.session
 zos.local.json
+deploy/configuration.json
+deploy/.*.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -620,7 +620,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   function setLandBalanceToken(address _newLandBalance) onlyProxyOwner external {
     require(_newLandBalance != address(0), "New landBalance should not be zero address");
     emit SetLandBalanceToken(landBalance, _newLandBalance);
-    landBalance = _newLandBalance;
+    landBalance = IMiniMeToken(_newLandBalance);
   }
 
    /**
@@ -628,9 +628,9 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
    * @notice Register land Balance
    */
   function registerBalance() external {
-    // Check that the balance of the sender is 0
-    uint256 registeredBalance = landBalance.balanceOf(msg.sender);
-    if (registeredBalance > 0) {
+    // Get balance of the sender is 0
+    uint256 currentBalance = landBalance.balanceOf(msg.sender);
+    if (currentBalance > 0) {
       require(
         landBalance.destroyTokens(msg.sender, currentBalance),
         "Register Balance::Could not destroy tokens"
@@ -640,12 +640,12 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     // Set balance as registered
     registeredBalance[msg.sender] = true;
 
-    // Get currennt LANDs balannce
-    uint256 currentBalance = estateRegistry.getLANDsSize(msg.sender);
+    // Get LAND balance
+    uint256 newBalance = getLANDsSize(msg.sender);
 
     // Generate Tokens
     require(
-      landBalance.generateTokens(msg.sender, currentBalance),
+      landBalance.generateTokens(msg.sender, newBalance),
       "Register Balance::Could not generate tokens"
     );
   }
@@ -658,12 +658,12 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     // Set balance as unregistered
     registeredBalance[msg.sender] = false;
 
-    // Check that the balance of the sender is 0
-    uint256 registeredBalance = landBalance.balanceOf(msg.sender);
+    // Get balance
+    uint256 currentBalance = landBalance.balanceOf(msg.sender);
 
     // Destroy Tokens
     require(
-      landBalance.destroyTokens(msg.sender, registeredBalance),
+      landBalance.destroyTokens(msg.sender, currentBalance),
       "Unregister Balance::Could not destroy tokens"
     );
   }

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -127,6 +127,22 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
+   * @notice Return the amount of LANDs inside the Estates for a given address
+   * @param _owner of the estates
+   * @return the amount of LANDs
+   */
+  function getLANDsSize(address _owner) public view returns (uint256) {
+    // Avoid balanceOf to not compute an unnecesary require
+    uint256 landsSize;
+    uint256 balance = ownedTokensCount[_owner];
+    for (uint256 i; i < balance; i++) {
+      uint256 estateId = ownedTokens[_owner][i];
+      landsSize += estateLandIds[estateId].length;
+    }
+    return landsSize;
+  }
+
+  /**
    * @notice Update the metadata of an Estate
    * @dev Reverts if the Estate does not exist or the user is not authorized
    * @param estateId Estate id to update

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -48,11 +48,6 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     _;
   }
 
-  modifier onlyProxyOwner() {
-    require(msg.sender == proxyOwner, "Unauthorized user");
-    _;
-  }
-
   /**
    * @dev Mint a new Estate with some metadata
    * @param to The address that will own the minted token
@@ -111,7 +106,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
     return landIdEstate[landId];
   }
 
-  function setLANDRegistry(address _registry) external onlyProxyOwner {
+  function setLANDRegistry(address _registry) external onlyOwner {
     require(_registry.isContract(), "The LAND registry address should be a contract");
     require(_registry != 0, "The LAND registry address should be valid");
     registry = LANDRegistry(_registry);
@@ -595,29 +590,10 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
-   * @dev Set the current owner as proxyOwner if it is empty
-   */
-  function initProxyOwner() external {
-    require(proxyOwner == address(0), "ProxyOwner can be initialized only once");
-    proxyOwner = address(0x9a6ebe7e2a7722f8200d0ffb63a1f6406a0d7dce);
-    emit ProxyOwnershipTransferred(address(0), proxyOwner);
-  }
-
-  /**
-   * @dev Set a new proxyOwner
-   * @notice Transfer Proxy Ownership to `_newProxyOwner`
-   */
-  function transferProxyOwnership(address _newProxyOwner) onlyProxyOwner external {
-    require(_newProxyOwner != address(0), "New proxyOwner should not be zero address");
-    emit ProxyOwnershipTransferred(proxyOwner, _newProxyOwner);
-    proxyOwner = _newProxyOwner;
-  }
-
-  /**
    * @dev Set a new estate land balance minime token
    * @notice Set new land balance token: `_newEstateLandBalance`
    */
-  function setEstateLandBalanceToken(address _newEstateLandBalance) onlyProxyOwner external {
+  function _setEstateLandBalanceToken(address _newEstateLandBalance) internal {
     require(_newEstateLandBalance != address(0), "New estateLandBalance should not be zero address");
     emit SetEstateLandBalanceToken(estateLandBalance, _newEstateLandBalance);
     estateLandBalance = IMiniMeToken(_newEstateLandBalance);

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -591,7 +591,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
 
   /**
    * @dev Set a new estate land balance minime token
-   * @notice Set new land balance token: `_newEstateLandBalance`
+   * @param _newEstateLandBalance address of the new estate land balance token
    */
   function _setEstateLandBalanceToken(address _newEstateLandBalance) internal {
     require(_newEstateLandBalance != address(0), "New estateLandBalance should not be zero address");

--- a/contracts/estate/EstateRegistry.sol
+++ b/contracts/estate/EstateRegistry.sol
@@ -628,7 +628,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
    * @notice Register land Balance
    */
   function registerBalance() external {
-    // Get balance of the sender is 0
+    // Get balance of the sender
     uint256 currentBalance = landBalance.balanceOf(msg.sender);
     if (currentBalance > 0) {
       require(
@@ -670,19 +670,16 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
 
   /**
    * @dev Update account balances
-   * @notice That if one of the account is the LANDRegistry, the operation will be omitted.
-   * The LANDRegistry has its own minime token.
    * @param _from account
    * @param _to account
    * @param _amount to update
    */
   function _updateLandBalance(address _from, address _to, uint256 _amount) internal {
-    address landRegistry = address(registry);
-    if (_from != landRegistry && registeredBalance[_from]) {
+    if (registeredBalance[_from]) {
       landBalance.destroyTokens(_from, _amount);
     }
 
-    if (_to != landRegistry && registeredBalance[_to]) {
+    if (registeredBalance[_to]) {
       landBalance.generateTokens(_to, _amount);
     }
   }

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -44,7 +44,7 @@ contract EstateStorage {
   address public proxyOwner;
 
   // Land balance minime token
-  IMiniMeToken public landBalance;
+  IMiniMeToken public estateLandBalance;
 
   // Registered balance accounts
   mapping(address => bool) public registeredBalance;

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -40,9 +40,6 @@ contract EstateStorage {
   // From account to mapping of operator to bool whether is allowed to update content or not
   mapping(address => mapping(address => bool)) public updateManager;
 
-  // Master role
-  address public proxyOwner;
-
   // Land balance minime token
   IMiniMeToken public estateLandBalance;
 

--- a/contracts/estate/EstateStorage.sol
+++ b/contracts/estate/EstateStorage.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.23;
 
+import "../minimeToken/IMinimeToken.sol";
 
 contract LANDRegistry {
   function decodeTokenId(uint value) external pure returns (int, int);
@@ -38,5 +39,14 @@ contract EstateStorage {
 
   // From account to mapping of operator to bool whether is allowed to update content or not
   mapping(address => mapping(address => bool)) public updateManager;
+
+  // Master role
+  address public proxyOwner;
+
+  // Land balance minime token
+  IMiniMeToken public landBalance;
+
+  // Registered balance accounts
+  mapping(address => bool) public registeredBalance;
 
 }

--- a/contracts/estate/IEstateRegistry.sol
+++ b/contracts/estate/IEstateRegistry.sol
@@ -47,11 +47,6 @@ contract IEstateRegistry {
     address indexed _registry
   );
 
-  event ProxyOwnershipTransferred(
-    address indexed _previousProxyOwner,
-    address indexed _newProxyOwner
-  );
-
   event SetEstateLandBalanceToken(
     address indexed _previousEstateLandBalance,
     address indexed _newEstateLandBalance

--- a/contracts/estate/IEstateRegistry.sol
+++ b/contracts/estate/IEstateRegistry.sol
@@ -46,4 +46,14 @@ contract IEstateRegistry {
   event SetLANDRegistry(
     address indexed _registry
   );
+
+  event ProxyOwnershipTransferred(
+    address indexed _previousProxyOwner,
+    address indexed _newProxyOwner
+  );
+
+  event SetLandBalanceToken(
+    address indexed _previousLandBalance,
+    address indexed _newLandBalance
+  );
 }

--- a/contracts/estate/IEstateRegistry.sol
+++ b/contracts/estate/IEstateRegistry.sol
@@ -52,8 +52,8 @@ contract IEstateRegistry {
     address indexed _newProxyOwner
   );
 
-  event SetLandBalanceToken(
-    address indexed _previousLandBalance,
-    address indexed _newLandBalance
+  event SetEstateLandBalanceToken(
+    address indexed _previousEstateLandBalance,
+    address indexed _newEstateLandBalance
   );
 }

--- a/contracts/land/ILANDRegistry.sol
+++ b/contracts/land/ILANDRegistry.sol
@@ -59,4 +59,9 @@ interface ILANDRegistry {
     address indexed _caller,
     address indexed _deployer
   );
+
+  event SetLandBalanceToken(
+    address indexed _previousLandBalance,
+    address indexed _newLandBalance
+  );
 }

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -481,7 +481,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   function setLandBalanceToken(address _newLandBalance) onlyProxyOwner external {
     require(_newLandBalance != address(0), "New landBalance should not be zero address");
     emit SetLandBalanceToken(landBalance, _newLandBalance);
-    landBalance = _newLandBalance;
+    landBalance = IMiniMeToken(_newLandBalance);
   }
 
    /**
@@ -489,9 +489,9 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Register land Balance
    */
   function registerBalance() external {
-    // Check that the balance of the sender is 0
-    uint256 registeredBalance = landBalance.balanceOf(msg.sender);
-    if (registeredBalance > 0) {
+    // Get balance of the sender is 0
+    uint256 currentBalance = landBalance.balanceOf(msg.sender);
+    if (currentBalance > 0) {
       require(
         landBalance.destroyTokens(msg.sender, currentBalance),
         "Register Balance::Could not destroy tokens"
@@ -502,11 +502,11 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     registeredBalance[msg.sender] = true;
 
     // Get LAND balance
-    uint256 currentBalannce = balanceOf(msg.sender);
+    uint256 newBalance = _balanceOf(msg.sender);
 
     // Generate Tokens
     require(
-      landBalance.generateTokens(msg.sender, currentBalannce),
+      landBalance.generateTokens(msg.sender, newBalance),
       "Register Balance::Could not generate tokens"
     );
   }
@@ -519,12 +519,12 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     // Set balance as unregistered
     registeredBalance[msg.sender] = false;
 
-    // Check that the balance of the sender is 0
-    uint256 registeredBalance = landBalance.balanceOf(msg.sender);
+    // Get balance
+    uint256 currentBalance = landBalance.balanceOf(msg.sender);
 
     // Destroy Tokens
     require(
-      landBalance.destroyTokens(msg.sender, registeredBalance),
+      landBalance.destroyTokens(msg.sender, currentBalance),
       "Unregister Balance::Could not destroy tokens"
     );
   }

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -489,7 +489,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Register land Balance
    */
   function registerBalance() external {
-    // Get balance of the sender is 0
+    // Get balance of the sender
     uint256 currentBalance = landBalance.balanceOf(msg.sender);
     if (currentBalance > 0) {
       require(
@@ -558,18 +558,15 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   /**
    * @dev Update account balances
-   * @notice That if one of the account is the EstateRegistry, the operation will be omitted.
-   * The EstateRegistry has its own minime token.
    * @param _from account
    * @param _to account
    */
   function _updateLandBalance(address _from, address _to) internal {
-    address estateContract = address(estateRegistry);
-    if (_from != estateContract && registeredBalance[_from]) {
+    if (registeredBalance[_from]) {
       landBalance.destroyTokens(_from, 1);
     }
 
-    if (_to != estateContract && registeredBalance[_to]) {
+    if (registeredBalance[_to]) {
       landBalance.generateTokens(_to, 1);
     }
   }

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -491,6 +491,8 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Register land Balance
    */
   function registerBalance() external {
+    require(!registeredBalance[msg.sender], "Register Balance::The user is already registered");
+
     // Get balance of the sender
     uint256 currentBalance = landBalance.balanceOf(msg.sender);
     if (currentBalance > 0) {
@@ -518,6 +520,8 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Unregister land Balance
    */
   function unregisterBalance() external {
+    require(registeredBalance[msg.sender], "Unregister Balance::The user not registered");
+
     // Set balance as unregistered
     registeredBalance[msg.sender] = false;
 

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -479,6 +479,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   /**
    * @dev Set a new land balance minime token
    * @notice Set new land balance token: `_newLandBalance`
+   * @param _newLandBalance address of the new land balance token
    */
   function setLandBalanceToken(address _newLandBalance) onlyProxyOwner external {
     require(_newLandBalance != address(0), "New landBalance should not be zero address");

--- a/contracts/land/LANDRegistry.sol
+++ b/contracts/land/LANDRegistry.sol
@@ -103,11 +103,13 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   function assignNewParcel(int x, int y, address beneficiary) external onlyDeployer {
     _generate(_encodeTokenId(x, y), beneficiary);
+    _updateLandBalance(address(0), beneficiary);
   }
 
   function assignMultipleParcels(int[] x, int[] y, address beneficiary) external onlyDeployer {
     for (uint i = 0; i < x.length; i++) {
       _generate(_encodeTokenId(x[i], y[i]), beneficiary);
+      _updateLandBalance(address(0), beneficiary);
     }
   }
 

--- a/contracts/land/LANDStorage.sol
+++ b/contracts/land/LANDStorage.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.23;
 
 import "../estate/IEstateRegistry.sol";
+import "../minimeToken/IMinimeToken.sol";
 
 
 contract LANDStorage {
@@ -19,4 +20,10 @@ contract LANDStorage {
   mapping (address => bool) public authorizedDeploy;
 
   mapping(address => mapping(address => bool)) public updateManager;
+
+  // Land balance minime token
+  IMiniMeToken public landBalance;
+
+  // Registered balance accounts
+  mapping(address => bool) public registeredBalance;
 }

--- a/contracts/minimeToken/IMinimeToken.sol
+++ b/contracts/minimeToken/IMinimeToken.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.24;
+
+
+interface IMiniMeToken {
+////////////////
+// Generate and destroy tokens
+////////////////
+
+    /// @notice Generates `_amount` tokens that are assigned to `_owner`
+    /// @param _owner The address that will be assigned the new tokens
+    /// @param _amount The quantity of tokens generated
+    /// @return True if the tokens are generated correctly
+    function generateTokens(address _owner, uint _amount) onlyController external returns (bool);
+
+
+    /// @notice Burns `_amount` tokens from `_owner`
+    /// @param _owner The address that will lose the tokens
+    /// @param _amount The quantity of tokens to burn
+    /// @return True if the tokens are burned correctly
+    function destroyTokens(address _owner, uint _amount) onlyController external returns (bool);
+
+    /// @param _owner The address that's balance is being requested
+    /// @return The balance of `_owner` at the current block
+    function balanceOf(address _owner) external constant returns (uint256 balance);
+}

--- a/contracts/minimeToken/IMinimeToken.sol
+++ b/contracts/minimeToken/IMinimeToken.sol
@@ -21,5 +21,7 @@ interface IMiniMeToken {
 
     /// @param _owner The address that's balance is being requested
     /// @return The balance of `_owner` at the current block
-    function balanceOf(address _owner) external constant returns (uint256 balance);
+    function balanceOf(address _owner) external view returns (uint256 balance);
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
 }

--- a/contracts/minimeToken/IMinimeToken.sol
+++ b/contracts/minimeToken/IMinimeToken.sol
@@ -10,14 +10,14 @@ interface IMiniMeToken {
     /// @param _owner The address that will be assigned the new tokens
     /// @param _amount The quantity of tokens generated
     /// @return True if the tokens are generated correctly
-    function generateTokens(address _owner, uint _amount) onlyController external returns (bool);
+    function generateTokens(address _owner, uint _amount) external returns (bool);
 
 
     /// @notice Burns `_amount` tokens from `_owner`
     /// @param _owner The address that will lose the tokens
     /// @param _amount The quantity of tokens to burn
     /// @return True if the tokens are burned correctly
-    function destroyTokens(address _owner, uint _amount) onlyController external returns (bool);
+    function destroyTokens(address _owner, uint _amount) external returns (bool);
 
     /// @param _owner The address that's balance is being requested
     /// @return The balance of `_owner` at the current block

--- a/contracts/minimeToken/ITokenController.sol
+++ b/contracts/minimeToken/ITokenController.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.4.24;
+
+/// @dev The token controller contract must implement these functions
+
+
+interface ITokenController {
+    /// @notice Called when `_owner` sends ether to the MiniMe Token contract
+    /// @param _owner The address that sent the ether to create tokens
+    /// @return True if the ether is accepted, false if it throws
+    function proxyPayment(address _owner) external payable returns(bool);
+
+    /// @notice Notifies the controller about a token transfer allowing the
+    ///  controller to react if desired
+    /// @param _from The origin of the transfer
+    /// @param _to The destination of the transfer
+    /// @param _amount The amount of the transfer
+    /// @return False if the controller does not authorize the transfer
+    function onTransfer(address _from, address _to, uint _amount) external returns(bool);
+
+    /// @notice Notifies the controller about an approval allowing the
+    ///  controller to react if desired
+    /// @param _owner The address that calls `approve()`
+    /// @param _spender The spender in the `approve()` call
+    /// @param _amount The amount in the `approve()` call
+    /// @return False if the controller does not authorize the approval
+    function onApprove(address _owner, address _spender, uint _amount) external returns(bool);
+}

--- a/contracts/minimeToken/MinimeToken.sol
+++ b/contracts/minimeToken/MinimeToken.sol
@@ -1,0 +1,579 @@
+pragma solidity ^0.4.24;
+
+/*
+    Copyright 2016, Jordi Baylina
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// @title MiniMeToken Contract
+/// @author Jordi Baylina
+/// @dev This token contract's goal is to make it easy for anyone to clone this
+///  token using the token distribution at a given block, this will allow DAO's
+///  and DApps to upgrade their features in a decentralized manner without
+///  affecting the original token
+/// @dev It is ERC20 compliant, but still needs to under go further testing.
+
+import "./ITokenController.sol";
+
+contract Controlled {
+    /// @notice The address of the controller is the only address that can call
+    ///  a function with this modifier
+    modifier onlyController {
+        require(msg.sender == controller);
+        _;
+    }
+
+    address public controller;
+
+    function Controlled()  public { controller = msg.sender;}
+
+    /// @notice Changes the controller of the contract
+    /// @param _newController The new controller of the contract
+    function changeController(address _newController) onlyController  public {
+        controller = _newController;
+    }
+}
+
+contract ApproveAndCallFallBack {
+    function receiveApproval(
+        address from,
+        uint256 _amount,
+        address _token,
+        bytes _data
+    ) public;
+}
+
+/// @dev The actual token contract, the default controller is the msg.sender
+///  that deploys the contract, so usually this token will be deployed by a
+///  token controller contract, which Giveth will call a "Campaign"
+contract MiniMeToken is Controlled {
+
+    string public name;                //The Token's name: e.g. DigixDAO Tokens
+    uint8 public decimals;             //Number of decimals of the smallest unit
+    string public symbol;              //An identifier: e.g. REP
+    string public version = "MMT_0.1"; //An arbitrary versioning scheme
+
+
+    /// @dev `Checkpoint` is the structure that attaches a block number to a
+    ///  given value, the block number attached is the one that last changed the
+    ///  value
+    struct Checkpoint {
+
+        // `fromBlock` is the block number that the value was generated from
+        uint128 fromBlock;
+
+        // `value` is the amount of tokens at a specific block number
+        uint128 value;
+    }
+
+    // `parentToken` is the Token address that was cloned to produce this token;
+    //  it will be 0x0 for a token that was not cloned
+    MiniMeToken public parentToken;
+
+    // `parentSnapShotBlock` is the block number from the Parent Token that was
+    //  used to determine the initial distribution of the Clone Token
+    uint public parentSnapShotBlock;
+
+    // `creationBlock` is the block number that the Clone Token was created
+    uint public creationBlock;
+
+    // `balances` is the map that tracks the balance of each address, in this
+    //  contract when the balance changes the block number that the change
+    //  occurred is also included in the map
+    mapping (address => Checkpoint[]) balances;
+
+    // `allowed` tracks any extra transfer rights as in all ERC20 tokens
+    mapping (address => mapping (address => uint256)) allowed;
+
+    // Tracks the history of the `totalSupply` of the token
+    Checkpoint[] totalSupplyHistory;
+
+    // Flag that determines if the token is transferable or not.
+    bool public transfersEnabled;
+
+    // The factory used to create new clone tokens
+    MiniMeTokenFactory public tokenFactory;
+
+////////////////
+// Constructor
+////////////////
+
+    /// @notice Constructor to create a MiniMeToken
+    /// @param _tokenFactory The address of the MiniMeTokenFactory contract that
+    ///  will create the Clone token contracts, the token factory needs to be
+    ///  deployed first
+    /// @param _parentToken Address of the parent token, set to 0x0 if it is a
+    ///  new token
+    /// @param _parentSnapShotBlock Block of the parent token that will
+    ///  determine the initial distribution of the clone token, set to 0 if it
+    ///  is a new token
+    /// @param _tokenName Name of the new token
+    /// @param _decimalUnits Number of decimals of the new token
+    /// @param _tokenSymbol Token Symbol for the new token
+    /// @param _transfersEnabled If true, tokens will be able to be transferred
+    function MiniMeToken(
+        MiniMeTokenFactory _tokenFactory,
+        MiniMeToken _parentToken,
+        uint _parentSnapShotBlock,
+        string _tokenName,
+        uint8 _decimalUnits,
+        string _tokenSymbol,
+        bool _transfersEnabled
+    )  public
+    {
+        tokenFactory = _tokenFactory;
+        name = _tokenName;                                 // Set the name
+        decimals = _decimalUnits;                          // Set the decimals
+        symbol = _tokenSymbol;                             // Set the symbol
+        parentToken = _parentToken;
+        parentSnapShotBlock = _parentSnapShotBlock;
+        transfersEnabled = _transfersEnabled;
+        creationBlock = block.number;
+    }
+
+
+///////////////////
+// ERC20 Methods
+///////////////////
+
+    /// @notice Send `_amount` tokens to `_to` from `msg.sender`
+    /// @param _to The address of the recipient
+    /// @param _amount The amount of tokens to be transferred
+    /// @return Whether the transfer was successful or not
+    function transfer(address _to, uint256 _amount) public returns (bool success) {
+        require(transfersEnabled);
+        return doTransfer(msg.sender, _to, _amount);
+    }
+
+    /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it
+    ///  is approved by `_from`
+    /// @param _from The address holding the tokens being transferred
+    /// @param _to The address of the recipient
+    /// @param _amount The amount of tokens to be transferred
+    /// @return True if the transfer was successful
+    function transferFrom(address _from, address _to, uint256 _amount) public returns (bool success) {
+
+        // The controller of this contract can move tokens around at will,
+        //  this is important to recognize! Confirm that you trust the
+        //  controller of this contract, which in most situations should be
+        //  another open source smart contract or 0x0
+        if (msg.sender != controller) {
+            require(transfersEnabled);
+
+            // The standard ERC 20 transferFrom functionality
+            if (allowed[_from][msg.sender] < _amount)
+                return false;
+            allowed[_from][msg.sender] -= _amount;
+        }
+        return doTransfer(_from, _to, _amount);
+    }
+
+    /// @dev This is the actual transfer function in the token contract, it can
+    ///  only be called by other functions in this contract.
+    /// @param _from The address holding the tokens being transferred
+    /// @param _to The address of the recipient
+    /// @param _amount The amount of tokens to be transferred
+    /// @return True if the transfer was successful
+    function doTransfer(address _from, address _to, uint _amount) internal returns(bool) {
+        if (_amount == 0) {
+            return true;
+        }
+        require(parentSnapShotBlock < block.number);
+        // Do not allow transfer to 0x0 or the token contract itself
+        require((_to != 0) && (_to != address(this)));
+        // If the amount being transfered is more than the balance of the
+        //  account the transfer returns false
+        var previousBalanceFrom = balanceOfAt(_from, block.number);
+        if (previousBalanceFrom < _amount) {
+            return false;
+        }
+        // Alerts the token controller of the transfer
+        if (isContract(controller)) {
+            // Adding the ` == true` makes the linter shut up so...
+            require(ITokenController(controller).onTransfer(_from, _to, _amount) == true);
+        }
+        // First update the balance array with the new value for the address
+        //  sending the tokens
+        updateValueAtNow(balances[_from], previousBalanceFrom - _amount);
+        // Then update the balance array with the new value for the address
+        //  receiving the tokens
+        var previousBalanceTo = balanceOfAt(_to, block.number);
+        require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
+        updateValueAtNow(balances[_to], previousBalanceTo + _amount);
+        // An event to make the transfer easy to find on the blockchain
+        Transfer(_from, _to, _amount);
+        return true;
+    }
+
+    /// @param _owner The address that's balance is being requested
+    /// @return The balance of `_owner` at the current block
+    function balanceOf(address _owner) public constant returns (uint256 balance) {
+        return balanceOfAt(_owner, block.number);
+    }
+
+    /// @notice `msg.sender` approves `_spender` to spend `_amount` tokens on
+    ///  its behalf. This is a modified version of the ERC20 approve function
+    ///  to be a little bit safer
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @param _amount The amount of tokens to be approved for transfer
+    /// @return True if the approval was successful
+    function approve(address _spender, uint256 _amount) public returns (bool success) {
+        require(transfersEnabled);
+
+        // To change the approve amount you first have to reduce the addresses`
+        //  allowance to zero by calling `approve(_spender,0)` if it is not
+        //  already 0 to mitigate the race condition described here:
+        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        require((_amount == 0) || (allowed[msg.sender][_spender] == 0));
+
+        // Alerts the token controller of the approve function call
+        if (isContract(controller)) {
+            // Adding the ` == true` makes the linter shut up so...
+            require(ITokenController(controller).onApprove(msg.sender, _spender, _amount) == true);
+        }
+
+        allowed[msg.sender][_spender] = _amount;
+        Approval(msg.sender, _spender, _amount);
+        return true;
+    }
+
+    /// @dev This function makes it easy to read the `allowed[]` map
+    /// @param _owner The address of the account that owns the token
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @return Amount of remaining tokens of _owner that _spender is allowed
+    ///  to spend
+    function allowance(address _owner, address _spender) public constant returns (uint256 remaining) {
+        return allowed[_owner][_spender];
+    }
+
+    /// @notice `msg.sender` approves `_spender` to send `_amount` tokens on
+    ///  its behalf, and then a function is triggered in the contract that is
+    ///  being approved, `_spender`. This allows users to use their tokens to
+    ///  interact with contracts in one function call instead of two
+    /// @param _spender The address of the contract able to transfer the tokens
+    /// @param _amount The amount of tokens to be approved for transfer
+    /// @return True if the function call was successful
+    function approveAndCall(ApproveAndCallFallBack _spender, uint256 _amount, bytes _extraData) public returns (bool success) {
+        require(approve(_spender, _amount));
+
+        _spender.receiveApproval(
+            msg.sender,
+            _amount,
+            this,
+            _extraData
+        );
+
+        return true;
+    }
+
+    /// @dev This function makes it easy to get the total number of tokens
+    /// @return The total number of tokens
+    function totalSupply() public constant returns (uint) {
+        return totalSupplyAt(block.number);
+    }
+
+
+////////////////
+// Query balance and totalSupply in History
+////////////////
+
+    /// @dev Queries the balance of `_owner` at a specific `_blockNumber`
+    /// @param _owner The address from which the balance will be retrieved
+    /// @param _blockNumber The block number when the balance is queried
+    /// @return The balance at `_blockNumber`
+    function balanceOfAt(address _owner, uint _blockNumber) public constant returns (uint) {
+
+        // These next few lines are used when the balance of the token is
+        //  requested before a check point was ever created for this token, it
+        //  requires that the `parentToken.balanceOfAt` be queried at the
+        //  genesis block for that token as this contains initial balance of
+        //  this token
+        if ((balances[_owner].length == 0) || (balances[_owner][0].fromBlock > _blockNumber)) {
+            if (address(parentToken) != 0) {
+                return parentToken.balanceOfAt(_owner, min(_blockNumber, parentSnapShotBlock));
+            } else {
+                // Has no parent
+                return 0;
+            }
+
+        // This will return the expected balance during normal situations
+        } else {
+            return getValueAt(balances[_owner], _blockNumber);
+        }
+    }
+
+    /// @notice Total amount of tokens at a specific `_blockNumber`.
+    /// @param _blockNumber The block number when the totalSupply is queried
+    /// @return The total amount of tokens at `_blockNumber`
+    function totalSupplyAt(uint _blockNumber) public constant returns(uint) {
+
+        // These next few lines are used when the totalSupply of the token is
+        //  requested before a check point was ever created for this token, it
+        //  requires that the `parentToken.totalSupplyAt` be queried at the
+        //  genesis block for this token as that contains totalSupply of this
+        //  token at this block number.
+        if ((totalSupplyHistory.length == 0) || (totalSupplyHistory[0].fromBlock > _blockNumber)) {
+            if (address(parentToken) != 0) {
+                return parentToken.totalSupplyAt(min(_blockNumber, parentSnapShotBlock));
+            } else {
+                return 0;
+            }
+
+        // This will return the expected totalSupply during normal situations
+        } else {
+            return getValueAt(totalSupplyHistory, _blockNumber);
+        }
+    }
+
+////////////////
+// Clone Token Method
+////////////////
+
+    /// @notice Creates a new clone token with the initial distribution being
+    ///  this token at `_snapshotBlock`
+    /// @param _cloneTokenName Name of the clone token
+    /// @param _cloneDecimalUnits Number of decimals of the smallest unit
+    /// @param _cloneTokenSymbol Symbol of the clone token
+    /// @param _snapshotBlock Block when the distribution of the parent token is
+    ///  copied to set the initial distribution of the new clone token;
+    ///  if the block is zero than the actual block, the current block is used
+    /// @param _transfersEnabled True if transfers are allowed in the clone
+    /// @return The address of the new MiniMeToken Contract
+    function createCloneToken(
+        string _cloneTokenName,
+        uint8 _cloneDecimalUnits,
+        string _cloneTokenSymbol,
+        uint _snapshotBlock,
+        bool _transfersEnabled
+    ) public returns(MiniMeToken)
+    {
+        uint256 snapshot = _snapshotBlock == 0 ? block.number - 1 : _snapshotBlock;
+
+        MiniMeToken cloneToken = tokenFactory.createCloneToken(
+            this,
+            snapshot,
+            _cloneTokenName,
+            _cloneDecimalUnits,
+            _cloneTokenSymbol,
+            _transfersEnabled
+        );
+
+        cloneToken.changeController(msg.sender);
+
+        // An event to make the token easy to find on the blockchain
+        NewCloneToken(address(cloneToken), snapshot);
+        return cloneToken;
+    }
+
+////////////////
+// Generate and destroy tokens
+////////////////
+
+    /// @notice Generates `_amount` tokens that are assigned to `_owner`
+    /// @param _owner The address that will be assigned the new tokens
+    /// @param _amount The quantity of tokens generated
+    /// @return True if the tokens are generated correctly
+    function generateTokens(address _owner, uint _amount) onlyController public returns (bool) {
+        uint curTotalSupply = totalSupply();
+        require(curTotalSupply + _amount >= curTotalSupply); // Check for overflow
+        uint previousBalanceTo = balanceOf(_owner);
+        require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
+        updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);
+        updateValueAtNow(balances[_owner], previousBalanceTo + _amount);
+        Transfer(0, _owner, _amount);
+        return true;
+    }
+
+
+    /// @notice Burns `_amount` tokens from `_owner`
+    /// @param _owner The address that will lose the tokens
+    /// @param _amount The quantity of tokens to burn
+    /// @return True if the tokens are burned correctly
+    function destroyTokens(address _owner, uint _amount) onlyController public returns (bool) {
+        uint curTotalSupply = totalSupply();
+        require(curTotalSupply >= _amount);
+        uint previousBalanceFrom = balanceOf(_owner);
+        require(previousBalanceFrom >= _amount);
+        updateValueAtNow(totalSupplyHistory, curTotalSupply - _amount);
+        updateValueAtNow(balances[_owner], previousBalanceFrom - _amount);
+        Transfer(_owner, 0, _amount);
+        return true;
+    }
+
+////////////////
+// Enable tokens transfers
+////////////////
+
+
+    /// @notice Enables token holders to transfer their tokens freely if true
+    /// @param _transfersEnabled True if transfers are allowed in the clone
+    function enableTransfers(bool _transfersEnabled) onlyController public {
+        transfersEnabled = _transfersEnabled;
+    }
+
+////////////////
+// Internal helper functions to query and set a value in a snapshot array
+////////////////
+
+    /// @dev `getValueAt` retrieves the number of tokens at a given block number
+    /// @param checkpoints The history of values being queried
+    /// @param _block The block number to retrieve the value at
+    /// @return The number of tokens being queried
+    function getValueAt(Checkpoint[] storage checkpoints, uint _block) constant internal returns (uint) {
+        if (checkpoints.length == 0)
+            return 0;
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length-1].fromBlock)
+            return checkpoints[checkpoints.length-1].value;
+        if (_block < checkpoints[0].fromBlock)
+            return 0;
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length-1;
+        while (max > min) {
+            uint mid = (max + min + 1) / 2;
+            if (checkpoints[mid].fromBlock<=_block) {
+                min = mid;
+            } else {
+                max = mid-1;
+            }
+        }
+        return checkpoints[min].value;
+    }
+
+    /// @dev `updateValueAtNow` used to update the `balances` map and the
+    ///  `totalSupplyHistory`
+    /// @param checkpoints The history of data being updated
+    /// @param _value The new number of tokens
+    function updateValueAtNow(Checkpoint[] storage checkpoints, uint _value) internal {
+        require(_value <= uint128(-1));
+
+        if ((checkpoints.length == 0) || (checkpoints[checkpoints.length - 1].fromBlock < block.number)) {
+            Checkpoint storage newCheckPoint = checkpoints[checkpoints.length++];
+            newCheckPoint.fromBlock = uint128(block.number);
+            newCheckPoint.value = uint128(_value);
+        } else {
+            Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length - 1];
+            oldCheckPoint.value = uint128(_value);
+        }
+    }
+
+    /// @dev Internal function to determine if an address is a contract
+    /// @param _addr The address being queried
+    /// @return True if `_addr` is a contract
+    function isContract(address _addr) constant internal returns(bool) {
+        uint size;
+        if (_addr == 0)
+            return false;
+
+        assembly {
+            size := extcodesize(_addr)
+        }
+
+        return size>0;
+    }
+
+    /// @dev Helper function to return a min betwen the two uints
+    function min(uint a, uint b) pure internal returns (uint) {
+        return a < b ? a : b;
+    }
+
+    /// @notice The fallback function: If the contract's controller has not been
+    ///  set to 0, then the `proxyPayment` method is called which relays the
+    ///  ether and creates tokens as described in the token controller contract
+    function () external payable {
+        require(isContract(controller));
+        // Adding the ` == true` makes the linter shut up so...
+        require(ITokenController(controller).proxyPayment.value(msg.value)(msg.sender) == true);
+    }
+
+//////////
+// Safety Methods
+//////////
+
+    /// @notice This method can be used by the controller to extract mistakenly
+    ///  sent tokens to this contract.
+    /// @param _token The address of the token contract that you want to recover
+    ///  set to 0 in case you want to extract ether.
+    function claimTokens(address _token) onlyController public {
+        if (_token == 0x0) {
+            controller.transfer(this.balance);
+            return;
+        }
+
+        MiniMeToken token = MiniMeToken(_token);
+        uint balance = token.balanceOf(this);
+        token.transfer(controller, balance);
+        ClaimedTokens(_token, controller, balance);
+    }
+
+////////////////
+// Events
+////////////////
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
+    event NewCloneToken(address indexed _cloneToken, uint _snapshotBlock);
+    event Approval(
+        address indexed _owner,
+        address indexed _spender,
+        uint256 _amount
+        );
+
+}
+
+
+////////////////
+// MiniMeTokenFactory
+////////////////
+
+/// @dev This contract is used to generate clone contracts from a contract.
+///  In solidity this is the way to create a contract from a contract of the
+///  same class
+contract MiniMeTokenFactory {
+    event NewFactoryCloneToken(address indexed _cloneToken, address indexed _parentToken, uint _snapshotBlock);
+
+    /// @notice Update the DApp by creating a new token with new functionalities
+    ///  the msg.sender becomes the controller of this clone token
+    /// @param _parentToken Address of the token being cloned
+    /// @param _snapshotBlock Block of the parent token that will
+    ///  determine the initial distribution of the clone token
+    /// @param _tokenName Name of the new token
+    /// @param _decimalUnits Number of decimals of the new token
+    /// @param _tokenSymbol Token Symbol for the new token
+    /// @param _transfersEnabled If true, tokens will be able to be transferred
+    /// @return The address of the new token contract
+    function createCloneToken(
+        MiniMeToken _parentToken,
+        uint _snapshotBlock,
+        string _tokenName,
+        uint8 _decimalUnits,
+        string _tokenSymbol,
+        bool _transfersEnabled
+    ) public returns (MiniMeToken)
+    {
+        MiniMeToken newToken = new MiniMeToken(
+            this,
+            _parentToken,
+            _snapshotBlock,
+            _tokenName,
+            _decimalUnits,
+            _tokenSymbol,
+            _transfersEnabled
+        );
+
+        newToken.changeController(msg.sender);
+        NewFactoryCloneToken(address(newToken), address(_parentToken), _snapshotBlock);
+        return newToken;
+    }
+}

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1659,7 +1659,7 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
 
   /**
    * @dev Set a new estate land balance minime token
-   * @notice Set new land balance token: `_newEstateLandBalance`
+   * @param _newEstateLandBalance address of the new estate land balance token
    */
   function _setEstateLandBalanceToken(address _newEstateLandBalance) internal {
     require(_newEstateLandBalance != address(0), "New estateLandBalance should not be zero address");

--- a/full/EstateRegistry.sol
+++ b/full/EstateRegistry.sol
@@ -1157,6 +1157,22 @@ contract EstateRegistry is Migratable, IEstateRegistry, ERC721Token, ERC721Recei
   }
 
   /**
+   * @notice Return the amount of LANDs inside the Estates for a given address
+   * @param _owner of the estates
+   * @return the amount of LANDs
+   */
+  function getLANDsSize(address _owner) public view returns (uint256) {
+    // Avoid balanceOf to not compute an unnecesary require
+    uint256 landsSize;
+    uint256 balance = ownedTokensCount[_owner];
+    for (uint256 i; i < balance; i++) {
+      uint256 estateId = ownedTokens[_owner][i];
+      landsSize += estateLandIds[estateId].length;
+    }
+    return landsSize;
+  }
+
+  /**
    * @notice Update the metadata of an Estate
    * @dev Reverts if the Estate does not exist or the user is not authorized
    * @param estateId Estate id to update

--- a/full/LANDProxy.sol
+++ b/full/LANDProxy.sol
@@ -116,14 +116,9 @@ contract IEstateRegistry {
     address indexed _registry
   );
 
-  event ProxyOwnershipTransferred(
-    address indexed _previousProxyOwner,
-    address indexed _newProxyOwner
-  );
-
-  event SetLandBalanceToken(
-    address indexed _previousLandBalance,
-    address indexed _newLandBalance
+  event SetEstateLandBalanceToken(
+    address indexed _previousEstateLandBalance,
+    address indexed _newEstateLandBalance
   );
 }
 

--- a/full/LANDProxy.sol
+++ b/full/LANDProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 // File: contracts/upgradable/ProxyStorage.sol
 
@@ -115,6 +115,41 @@ contract IEstateRegistry {
   event SetLANDRegistry(
     address indexed _registry
   );
+
+  event ProxyOwnershipTransferred(
+    address indexed _previousProxyOwner,
+    address indexed _newProxyOwner
+  );
+
+  event SetLandBalanceToken(
+    address indexed _previousLandBalance,
+    address indexed _newLandBalance
+  );
+}
+
+// File: contracts/minimeToken/IMinimeToken.sol
+
+interface IMiniMeToken {
+////////////////
+// Generate and destroy tokens
+////////////////
+
+    /// @notice Generates `_amount` tokens that are assigned to `_owner`
+    /// @param _owner The address that will be assigned the new tokens
+    /// @param _amount The quantity of tokens generated
+    /// @return True if the tokens are generated correctly
+    function generateTokens(address _owner, uint _amount) onlyController external returns (bool);
+
+
+    /// @notice Burns `_amount` tokens from `_owner`
+    /// @param _owner The address that will lose the tokens
+    /// @param _amount The quantity of tokens to burn
+    /// @return True if the tokens are burned correctly
+    function destroyTokens(address _owner, uint _amount) onlyController external returns (bool);
+
+    /// @param _owner The address that's balance is being requested
+    /// @return The balance of `_owner` at the current block
+    function balanceOf(address _owner) external constant returns (uint256 balance);
 }
 
 // File: contracts/land/LANDStorage.sol
@@ -135,6 +170,12 @@ contract LANDStorage {
   mapping (address => bool) public authorizedDeploy;
 
   mapping(address => mapping(address => bool)) public updateManager;
+
+  // Land balance minime token
+  IMiniMeToken public landBalance;
+
+  // Registered balance accounts
+  mapping(address => bool) public registeredBalance;
 }
 
 // File: contracts/Storage.sol

--- a/full/LANDProxy.sol
+++ b/full/LANDProxy.sol
@@ -138,18 +138,20 @@ interface IMiniMeToken {
     /// @param _owner The address that will be assigned the new tokens
     /// @param _amount The quantity of tokens generated
     /// @return True if the tokens are generated correctly
-    function generateTokens(address _owner, uint _amount) onlyController external returns (bool);
+    function generateTokens(address _owner, uint _amount) external returns (bool);
 
 
     /// @notice Burns `_amount` tokens from `_owner`
     /// @param _owner The address that will lose the tokens
     /// @param _amount The quantity of tokens to burn
     /// @return True if the tokens are burned correctly
-    function destroyTokens(address _owner, uint _amount) onlyController external returns (bool);
+    function destroyTokens(address _owner, uint _amount) external returns (bool);
 
     /// @param _owner The address that's balance is being requested
     /// @return The balance of `_owner` at the current block
-    function balanceOf(address _owner) external constant returns (uint256 balance);
+    function balanceOf(address _owner) external view returns (uint256 balance);
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
 }
 
 // File: contracts/land/LANDStorage.sol

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -138,18 +138,20 @@ interface IMiniMeToken {
     /// @param _owner The address that will be assigned the new tokens
     /// @param _amount The quantity of tokens generated
     /// @return True if the tokens are generated correctly
-    function generateTokens(address _owner, uint _amount) onlyController external returns (bool);
+    function generateTokens(address _owner, uint _amount) external returns (bool);
 
 
     /// @notice Burns `_amount` tokens from `_owner`
     /// @param _owner The address that will lose the tokens
     /// @param _amount The quantity of tokens to burn
     /// @return True if the tokens are burned correctly
-    function destroyTokens(address _owner, uint _amount) onlyController external returns (bool);
+    function destroyTokens(address _owner, uint _amount) external returns (bool);
 
     /// @param _owner The address that's balance is being requested
     /// @return The balance of `_owner` at the current block
-    function balanceOf(address _owner) external constant returns (uint256 balance);
+    function balanceOf(address _owner) external view returns (uint256 balance);
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
 }
 
 // File: contracts/land/LANDStorage.sol
@@ -1422,7 +1424,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   function setLandBalanceToken(address _newLandBalance) onlyProxyOwner external {
     require(_newLandBalance != address(0), "New landBalance should not be zero address");
     emit SetLandBalanceToken(landBalance, _newLandBalance);
-    landBalance = _newLandBalance;
+    landBalance = IMiniMeToken(_newLandBalance);
   }
 
    /**
@@ -1430,9 +1432,9 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Register land Balance
    */
   function registerBalance() external {
-    // Check that the balance of the sender is 0
-    uint256 registeredBalance = landBalance.balanceOf(msg.sender);
-    if (registeredBalance > 0) {
+    // Get balance of the sender
+    uint256 currentBalance = landBalance.balanceOf(msg.sender);
+    if (currentBalance > 0) {
       require(
         landBalance.destroyTokens(msg.sender, currentBalance),
         "Register Balance::Could not destroy tokens"
@@ -1443,11 +1445,11 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     registeredBalance[msg.sender] = true;
 
     // Get LAND balance
-    uint256 currentBalannce = balanceOf(msg.sender);
+    uint256 newBalance = _balanceOf(msg.sender);
 
     // Generate Tokens
     require(
-      landBalance.generateTokens(msg.sender, currentBalannce),
+      landBalance.generateTokens(msg.sender, newBalance),
       "Register Balance::Could not generate tokens"
     );
   }
@@ -1460,12 +1462,12 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
     // Set balance as unregistered
     registeredBalance[msg.sender] = false;
 
-    // Check that the balance of the sender is 0
-    uint256 registeredBalance = landBalance.balanceOf(msg.sender);
+    // Get balance
+    uint256 currentBalance = landBalance.balanceOf(msg.sender);
 
     // Destroy Tokens
     require(
-      landBalance.destroyTokens(msg.sender, registeredBalance),
+      landBalance.destroyTokens(msg.sender, currentBalance),
       "Unregister Balance::Could not destroy tokens"
     );
   }
@@ -1499,18 +1501,15 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   /**
    * @dev Update account balances
-   * @notice That if one of the account is the EstateRegistry, the operation will be omitted.
-   * The EstateRegistry has its own minime token.
    * @param _from account
    * @param _to account
    */
   function _updateLandBalance(address _from, address _to) internal {
-    address estateContract = address(estateRegistry);
-    if (_from != estateContract && registeredBalance[_from]) {
+    if (registeredBalance[_from]) {
       landBalance.destroyTokens(_from, 1);
     }
 
-    if (_to != estateContract && registeredBalance[_to]) {
+    if (registeredBalance[_to]) {
       landBalance.generateTokens(_to, 1);
     }
   }

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -1046,11 +1046,13 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
 
   function assignNewParcel(int x, int y, address beneficiary) external onlyDeployer {
     _generate(_encodeTokenId(x, y), beneficiary);
+    _updateLandBalance(address(0), beneficiary);
   }
 
   function assignMultipleParcels(int[] x, int[] y, address beneficiary) external onlyDeployer {
     for (uint i = 0; i < x.length; i++) {
       _generate(_encodeTokenId(x[i], y[i]), beneficiary);
+      _updateLandBalance(address(0), beneficiary);
     }
   }
 

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -1417,6 +1417,7 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
   /**
    * @dev Set a new land balance minime token
    * @notice Set new land balance token: `_newLandBalance`
+   * @param _newLandBalance address of the new land balance token
    */
   function setLandBalanceToken(address _newLandBalance) onlyProxyOwner external {
     require(_newLandBalance != address(0), "New landBalance should not be zero address");

--- a/full/LANDRegistry.sol
+++ b/full/LANDRegistry.sol
@@ -116,14 +116,9 @@ contract IEstateRegistry {
     address indexed _registry
   );
 
-  event ProxyOwnershipTransferred(
-    address indexed _previousProxyOwner,
-    address indexed _newProxyOwner
-  );
-
-  event SetLandBalanceToken(
-    address indexed _previousLandBalance,
-    address indexed _newLandBalance
+  event SetEstateLandBalanceToken(
+    address indexed _previousEstateLandBalance,
+    address indexed _newEstateLandBalance
   );
 }
 
@@ -1434,6 +1429,8 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Register land Balance
    */
   function registerBalance() external {
+    require(!registeredBalance[msg.sender], "Register Balance::The user is already registered");
+
     // Get balance of the sender
     uint256 currentBalance = landBalance.balanceOf(msg.sender);
     if (currentBalance > 0) {
@@ -1461,6 +1458,8 @@ contract LANDRegistry is Storage, Ownable, FullAssetRegistry, ILANDRegistry {
    * @notice Unregister land Balance
    */
   function unregisterBalance() external {
+    require(registeredBalance[msg.sender], "Unregister Balance::The user not registered");
+
     // Set balance as unregistered
     registeredBalance[msg.sender] = false;
 

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -10,6 +10,7 @@ const BigNumber = web3.BigNumber
 
 const EstateRegistry = artifacts.require('EstateRegistryTest')
 const LANDProxy = artifacts.require('LANDProxy')
+const MiniMeToken = artifacts.require('MiniMeToken')
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 const CURRENT_OWNER = '0x9a6ebe7e2a7722f8200d0ffb63a1f6406a0d7dce'
@@ -126,11 +127,8 @@ contract('EstateRegistry', accounts => {
     owner.should.be.equal(expectedOwner)
   }
 
-  function transferOut(estateId, index, who) {
-    if (!who) {
-      who = sentByUser
-    }
-    return estate.transferLand(estateId, index, anotherUser, who)
+  function transferOut(estateId, index, who = sentByUser, to = anotherUser) {
+    return estate.transferLand(estateId, index, to, who)
   }
 
   function transferIn(estateId, landId, userAddress = anotherUser) {
@@ -1752,6 +1750,476 @@ contract('EstateRegistry', accounts => {
       proxyOwner.should.be.equal(CURRENT_OWNER)
 
       await assertRevert(contract.initProxyOwner())
+    })
+  })
+
+  describe('LandBalance', function() {
+    let landBalance
+    let estateBalance
+    let estateId1
+
+    async function getEstateBalanceEvents(eventName) {
+      return new Promise((resolve, reject) => {
+        estateBalance[eventName]().get(function(err, logs) {
+          if (err) reject(new Error(`Error fetching the ${eventName} events`))
+          resolve(logs)
+        })
+      })
+    }
+
+    beforeEach(async function() {
+      landBalance = MiniMeToken.at(await land.landBalance())
+      estateBalance = MiniMeToken.at(await estate.landBalance())
+
+      estateId1 = await createUserEstateWithNumberedTokens()
+    })
+
+    describe('setBalanceToken', function() {
+      it('should set balance token', async function() {
+        const { logs } = await estate.setLandBalanceToken(user, sentByCreator)
+
+        // Event emitted
+        logs.length.should.be.equal(1)
+
+        const log = logs[0]
+        log.event.should.be.eq('SetLandBalanceToken')
+        log.args._previousLandBalance.should.be.equal(estateBalance.address)
+        log.args._newLandBalance.should.be.equal(user)
+      })
+
+      it('reverts if a hacker try to set balance token', async function() {
+        await assertRevert(estate.setLandBalanceToken(user, sentByHacker))
+      })
+    })
+
+    describe('Register balance', function() {
+      it('should register balance', async function() {
+        const isRegistered = await estate.registeredBalance(user)
+        expect(isRegistered).equal(false)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        // Register
+        await estate.registerBalance(sentByUser)
+        const logs = await getEstateBalanceEvents('Transfer')
+        logs.length.should.be.equal(1)
+
+        const log = logs[0]
+        log.event.should.be.eq('Transfer')
+        log.args._from.should.be.equal(EMPTY_ADDRESS)
+        log.args._to.should.be.equal(user)
+        log.args._amount.should.be.bignumber.equal(5)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        await land.assignNewParcel(0, 6, user, sentByCreator)
+        await createEstate([0], [6], user, sentByUser)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(6)
+
+        await transferOut(estateId1, 1, sentByUser)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+      })
+
+      it('should re-register balance', async function() {
+        let isRegistered = await estate.registeredBalance(anotherUser)
+        expect(isRegistered).equal(false)
+
+        let anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await land.assignNewParcel(0, 6, anotherUser, sentByCreator)
+        await createEstate([0], [6], anotherUser, sentByAnotherUser)
+
+        // Balance should keep as 0
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await estate.registerBalance(sentByAnotherUser)
+
+        isRegistered = await estate.registeredBalance(anotherUser)
+        expect(isRegistered).equal(true)
+
+        // Balance should be 1
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(1)
+
+        // Register again
+        await estate.registerBalance(sentByAnotherUser)
+
+        // Balance should be 1
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(1)
+
+        await land.assignNewParcel(0, 7, anotherUser, sentByCreator)
+        await createEstate([0], [7], anotherUser, sentByAnotherUser)
+
+        // Register again
+        await estate.registerBalance(sentByAnotherUser)
+        const logs = await getEstateBalanceEvents('Transfer')
+        logs.length.should.be.equal(2)
+
+        let log = logs[0]
+        log.event.should.be.eq('Transfer')
+        log.args._from.should.be.equal(anotherUser)
+        log.args._to.should.be.equal(EMPTY_ADDRESS)
+        log.args._amount.should.be.bignumber.equal(2)
+
+        log = logs[1]
+        log.event.should.be.eq('Transfer')
+        log.args._from.should.be.equal(EMPTY_ADDRESS)
+        log.args._to.should.be.equal(anotherUser)
+        log.args._amount.should.be.bignumber.equal(2)
+
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(2)
+      })
+
+      it('should unregister balance', async function() {
+        // Register
+        await estate.registerBalance(sentByUser)
+
+        let isRegistered = await estate.registeredBalance(user)
+        expect(isRegistered).equal(true)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        // Unregister
+        await estate.unregisterBalance(sentByUser)
+
+        const logs = await getEstateBalanceEvents('Transfer')
+        logs.length.should.be.equal(1)
+
+        const log = logs[0]
+        log.event.should.be.eq('Transfer')
+        log.args._from.should.be.equal(user)
+        log.args._to.should.be.equal(EMPTY_ADDRESS)
+        log.args._amount.should.be.bignumber.equal(5)
+
+        isRegistered = await estate.registeredBalance(user)
+        expect(isRegistered).equal(false)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+      })
+    })
+
+    describe('Update balance', function() {
+      beforeEach(async function() {
+        await estate.registerBalance(sentByUser)
+      })
+
+      it('should register balance only one balance', async function() {
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        await estate.transferFrom(user, anotherUser, estateId1, sentByUser)
+
+        userBalance = await landBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        const isAnotherUserRegistered = await land.registeredBalance(
+          anotherUser
+        )
+        expect(isAnotherUserRegistered).equal(false)
+
+        const anotherUserBalance = await landBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        let landRegistryBalance = await landBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+      })
+
+      it('should register owner balance if it was transferred by operator :: approvalForAll', async function() {
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        await estate.setApprovalForAll(operator, true, sentByUser)
+        await estate.transferFrom(user, anotherUser, estateId1, sentByOperator)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        const operatorBalance = await estateBalance.balanceOf(operator)
+        operatorBalance.should.be.bignumber.equal(0)
+
+        const anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+      })
+
+      it('should register owner balance if it was transferred by operator :: Operator', async function() {
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        await estate.approve(operator, estateId1, sentByUser)
+        await estate.transferFrom(user, anotherUser, estateId1, sentByOperator)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        const operatorBalance = await estateBalance.balanceOf(operator)
+        operatorBalance.should.be.bignumber.equal(0)
+
+        const anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+      })
+
+      it('should register balance both', async function() {
+        await estate.registerBalance(sentByAnotherUser)
+
+        const isAnotherUserRegistered = await estate.registeredBalance(
+          anotherUser
+        )
+        expect(isAnotherUserRegistered).equal(true)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        await estate.transferFrom(user, anotherUser, estateId1, sentByUser)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        const anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(5)
+      })
+
+      it('should not register transfer to the land registry', async function() {
+        const isLANDRegistered = await estate.registeredBalance(land.address)
+        expect(isLANDRegistered).equal(false)
+
+        const isEstateRegistered = await land.registeredBalance(estate.address)
+        expect(isEstateRegistered).equal(false)
+
+        let userBalance = await landBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        let userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(5)
+
+        let estateRegistryBalance = await landBalance.balanceOf(estate.address)
+        estateRegistryBalance.should.be.bignumber.equal(0)
+
+        let landRegistryBalance = await estateBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+
+        await land.assignNewParcel(0, 6, user, sentByCreator)
+
+        userBalance = await landBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(5)
+
+        estateRegistryBalance = await estateBalance.balanceOf(estate.address)
+        estateRegistryBalance.should.be.bignumber.equal(0)
+
+        landRegistryBalance = await estateBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+
+        await land.transferLandToEstate(0, 6, estateId1, sentByUser)
+
+        userBalance = await landBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(6)
+
+        estateRegistryBalance = await landBalance.balanceOf(estate.address)
+        estateRegistryBalance.should.be.bignumber.equal(0)
+
+        landRegistryBalance = await estateBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+
+        await transferOut(estateId1, 1, sentByUser)
+
+        let anotherUserBalance = await landBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await land.registerBalance(sentByAnotherUser)
+
+        anotherUserBalance = await landBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(1)
+      })
+
+      it('should register land balance and estate balance', async function() {
+        await land.registerBalance(sentByUser)
+
+        let isEstateRegistered = await land.registeredBalance(estate.address)
+        expect(isEstateRegistered).equal(false)
+
+        let isLANDRegistered = await estate.registeredBalance(land.address)
+        expect(isLANDRegistered).equal(false)
+
+        let userLandBalance = await landBalance.balanceOf(user)
+        userLandBalance.should.be.bignumber.equal(0)
+
+        let userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(5)
+
+        let estateRegistryBalance = await landBalance.balanceOf(estate.address)
+        estateRegistryBalance.should.be.bignumber.equal(0)
+
+        let landRegistryBalance = await estateBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+
+        await transferOut(estateId1, 1, sentByUser, user)
+
+        userLandBalance = await landBalance.balanceOf(user)
+        userLandBalance.should.be.bignumber.equal(1)
+
+        userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(4)
+
+        estateRegistryBalance = await landBalance.balanceOf(estate.address)
+        estateRegistryBalance.should.be.bignumber.equal(0)
+
+        landRegistryBalance = await estateBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+
+        await transferOut(estateId1, 2, sentByUser, user)
+
+        userLandBalance = await landBalance.balanceOf(user)
+        userLandBalance.should.be.bignumber.equal(2)
+
+        userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(3)
+
+        estateRegistryBalance = await landBalance.balanceOf(estate.address)
+        estateRegistryBalance.should.be.bignumber.equal(0)
+
+        landRegistryBalance = await estateBalance.balanceOf(land.address)
+        landRegistryBalance.should.be.bignumber.equal(0)
+
+        let ownLandBalance = await landBalance.balanceOf(land.address)
+        ownLandBalance.should.be.bignumber.equal(0)
+
+        let ownEstateBalance = await estateBalance.balanceOf(estate.address)
+        ownEstateBalance.should.be.bignumber.equal(0)
+
+        let operatorLandBalance = await landBalance.balanceOf(operator)
+        operatorLandBalance.should.be.bignumber.equal(0)
+
+        let operatorEstateBalance = await estateBalance.balanceOf(operator)
+        operatorEstateBalance.should.be.bignumber.equal(0)
+
+        await estate.transferManyLands(estateId1, [3, 4], operator, sentByUser)
+
+        operatorLandBalance = await landBalance.balanceOf(operator)
+        operatorLandBalance.should.be.bignumber.equal(0)
+
+        operatorEstateBalance = await estateBalance.balanceOf(operator)
+        operatorEstateBalance.should.be.bignumber.equal(0)
+
+        await land.registerBalance(sentByUser)
+        await land.registerBalance(sentByOperator)
+        await estate.registerBalance(sentByUser)
+        await estate.registerBalance(sentByOperator)
+
+        userLandBalance = await landBalance.balanceOf(user)
+        userLandBalance.should.be.bignumber.equal(2)
+
+        userEstateBalance = await estateBalance.balanceOf(user)
+        userEstateBalance.should.be.bignumber.equal(1)
+
+        operatorLandBalance = await landBalance.balanceOf(operator)
+        operatorLandBalance.should.be.bignumber.equal(2)
+
+        operatorEstateBalance = await estateBalance.balanceOf(operator)
+        operatorEstateBalance.should.be.bignumber.equal(0)
+      })
+
+      it('should update on transfer :: transferFrom', async function() {
+        await estate.registerBalance(sentByAnotherUser)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        let anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await estate.transferFrom(user, anotherUser, estateId1, sentByUser)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(5)
+      })
+
+      it('should update on transfer :: safeTransferFrom', async function() {
+        await estate.registerBalance(sentByAnotherUser)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        let anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await estate.safeTransferFrom(user, anotherUser, estateId1, sentByUser)
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(5)
+      })
+
+      it('should update on transfer :: safeTransferFrom with bytes', async function() {
+        await estate.registerBalance(sentByAnotherUser)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(5)
+
+        let anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await estate.safeTransferFromWithBytes(
+          user,
+          anotherUser,
+          estateId1,
+          '0x00',
+          sentByUser
+        )
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(5)
+      })
+
+      it('should update on transfer :: safeTransferManyFrom', async function() {
+        await estate.registerBalance(sentByAnotherUser)
+
+        await land.assignNewParcel(0, 6, user, sentByCreator)
+        const estateId2 = await createEstate([0], [6], user, sentByUser)
+
+        let userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(6)
+
+        let anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(0)
+
+        await estate.safeTransferManyFrom(
+          user,
+          anotherUser,
+          [estateId1, estateId2],
+          sentByUser
+        )
+
+        userBalance = await estateBalance.balanceOf(user)
+        userBalance.should.be.bignumber.equal(0)
+
+        anotherUserBalance = await estateBalance.balanceOf(anotherUser)
+        anotherUserBalance.should.be.bignumber.equal(6)
+      })
     })
   })
 })

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -1588,4 +1588,90 @@ contract('EstateRegistry', accounts => {
       )
     })
   })
+
+  describe('LANDs size', function() {
+    it('should return the amount of LANDs', async () => {
+      const estateId1 = await createUserEstateWithNumberedTokens()
+
+      await land.assignMultipleParcels([1], [1], user, sentByCreator)
+      const estateId2 = await createEstate([1], [1], user, sentByUser)
+
+      await land.assignMultipleParcels([1, 1], [2, 3], user, sentByCreator)
+      const estateId3 = await createEstate([1, 1], [2, 3], user, sentByUser)
+
+      let totalSize = (await estate.getEstateSize(estateId1)).toNumber()
+      totalSize += (await estate.getEstateSize(estateId2)).toNumber()
+      totalSize += (await estate.getEstateSize(estateId3)).toNumber()
+
+      const LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(totalSize)
+    })
+
+    it('should update the amount of LANDs', async () => {
+      const estateId1 = await createUserEstateWithNumberedTokens()
+
+      await land.assignMultipleParcels([1], [1], user, sentByCreator)
+      const estateId2 = await createEstate([1], [1], user, sentByUser)
+
+      await land.assignMultipleParcels([1, 1], [2, 3], user, sentByCreator)
+      const estateId3 = await createEstate([1, 1], [2, 3], user, sentByUser)
+
+      let totalSize = (await estate.getEstateSize(estateId1)).toNumber()
+      totalSize += (await estate.getEstateSize(estateId2)).toNumber()
+      totalSize += (await estate.getEstateSize(estateId3)).toNumber()
+
+      let LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(totalSize)
+      totalSize.should.be.equal(8)
+
+      await land.assignMultipleParcels(
+        [1, 1, 1, 1],
+        [4, 5, 6, 7],
+        user,
+        sentByCreator
+      )
+      const estateId4 = await createEstate(
+        [1, 1, 1, 1],
+        [4, 5, 6, 7],
+        user,
+        sentByUser
+      )
+
+      totalSize += (await estate.getEstateSize(estateId4)).toNumber()
+
+      LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(totalSize)
+      totalSize.should.be.equal(12)
+
+      await transferOut(estateId1, 1)
+
+      totalSize--
+
+      LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(totalSize)
+      totalSize.should.be.equal(11)
+
+      await land.assignMultipleParcels([0], [8], user, sentByCreator)
+      // Estate4 should have 5 LANDs now
+      await transferIn(estateId4, 8, user)
+
+      totalSize++
+
+      LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(totalSize)
+      totalSize.should.be.equal(12)
+
+      await estate.safeTransferFrom(user, anotherUser, estateId4, sentByUser)
+      totalSize -= (await estate.getEstateSize(estateId4)).toNumber()
+
+      LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(totalSize)
+      totalSize.should.be.equal(7)
+    })
+
+    it('should returns 0 for an address with 0 Estates', async () => {
+      const LANDSize = await estate.getLANDsSize(user)
+      LANDSize.toNumber().should.be.equal(0)
+    })
+  })
 })

--- a/test/EstateRegistry.js
+++ b/test/EstateRegistry.js
@@ -1675,84 +1675,6 @@ contract('EstateRegistry', accounts => {
     })
   })
 
-  describe('ProxyOwner', function() {
-    let contract
-    beforeEach(async () => {
-      contract = await EstateRegistry.new(
-        ESTATE_NAME,
-        ESTATE_SYMBOL,
-        land.address,
-        creationParams
-      )
-    })
-    it('should init proxyOwner to dcl Multisig', async function() {
-      let proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(EMPTY_ADDRESS)
-
-      const { logs } = await contract.initProxyOwner()
-      logs.length.should.be.equal(1)
-      logs[0].event.should.be.equal('ProxyOwnershipTransferred')
-      logs[0].args._previousProxyOwner.should.be.equal(EMPTY_ADDRESS)
-      logs[0].args._newProxyOwner.should.be.bignumber.equal(CURRENT_OWNER)
-
-      proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(CURRENT_OWNER)
-    })
-
-    it('should transfer proxyOwner', async function() {
-      await contract.initAndChangeProxyOwner(creator)
-
-      let proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(creator)
-
-      const { logs } = await contract.transferProxyOwnership(
-        user,
-        sentByCreator
-      )
-      logs.length.should.be.equal(1)
-      logs[0].event.should.be.equal('ProxyOwnershipTransferred')
-      logs[0].args._previousProxyOwner.should.be.equal(creator)
-      logs[0].args._newProxyOwner.should.be.bignumber.equal(user)
-
-      proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(user)
-    })
-
-    it('reverts when transferring proxyOwner by unauthorized user', async function() {
-      await contract.initAndChangeProxyOwner(creator)
-      let proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(creator)
-
-      await assertRevert(contract.transferProxyOwnership(user, sentByHacker))
-    })
-
-    it('reverts if trying to init proxyOwner after transferred', async function() {
-      let proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(EMPTY_ADDRESS)
-
-      await contract.initAndChangeProxyOwner(creator)
-
-      await contract.transferProxyOwnership(user, sentByCreator)
-
-      proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(user)
-
-      await assertRevert(contract.initProxyOwner())
-    })
-
-    it('reverts if trying to init proxyOwner more than once', async function() {
-      let proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(EMPTY_ADDRESS)
-
-      await contract.initProxyOwner()
-
-      proxyOwner = await contract.proxyOwner()
-      proxyOwner.should.be.equal(CURRENT_OWNER)
-
-      await assertRevert(contract.initProxyOwner())
-    })
-  })
-
   describe('LandBalance', function() {
     let landBalance
     let estateBalance
@@ -1790,10 +1712,6 @@ contract('EstateRegistry', accounts => {
           estateBalance.address
         )
         log.args._newEstateLandBalance.should.be.equal(user)
-      })
-
-      it('reverts if a hacker try to set balance token', async function() {
-        await assertRevert(estate.setEstateLandBalanceToken(user, sentByHacker))
       })
     })
 

--- a/test/EstateRegistryTest.sol
+++ b/test/EstateRegistryTest.sol
@@ -30,18 +30,23 @@ contract EstateRegistryTest is EstateRegistry {
   }
 
   function safeTransferFromWithBytes(
-    address from, 
-    address to, 
-    uint256 assetId, 
+    address from,
+    address to,
+    uint256 assetId,
     bytes data
-  ) 
-    public 
+  )
+    public
   {
     safeTransferFrom(
-      from, 
+      from,
       to,
-      assetId, 
+      assetId,
       data
     );
+  }
+
+  function initAndChangeProxyOwner(address _address) public {
+    this.initProxyOwner();
+    proxyOwner = _address;
   }
 }

--- a/test/EstateRegistryTest.sol
+++ b/test/EstateRegistryTest.sol
@@ -45,8 +45,7 @@ contract EstateRegistryTest is EstateRegistry {
     );
   }
 
-  function initAndChangeProxyOwner(address _address) public {
-    this.initProxyOwner();
-    proxyOwner = _address;
+  function setEstateLandBalanceToken(address _newEstateLandBalance) public {
+    _setEstateLandBalanceToken(_newEstateLandBalance);
   }
 }

--- a/test/LANDRegistry.js
+++ b/test/LANDRegistry.js
@@ -5,7 +5,7 @@ import setupContracts, {
 } from './helpers/setupContracts'
 import createEstateFull from './helpers/createEstateFull'
 
-const MinimeToken = artifacts.require('MinimeToken')
+const MiniMeToken = artifacts.require('MiniMeToken')
 
 const BigNumber = web3.BigNumber
 
@@ -1223,8 +1223,8 @@ contract('LANDRegistry', accounts => {
     }
 
     beforeEach(async function() {
-      landBalance = MinimeToken.at(await land.landBalance())
-      estateBalance = MinimeToken.at(await estate.landBalance())
+      landBalance = MiniMeToken.at(await land.landBalance())
+      estateBalance = MiniMeToken.at(await estate.landBalance())
     })
 
     describe('setBalanceToken', function() {
@@ -1376,7 +1376,7 @@ contract('LANDRegistry', accounts => {
         landRegistryBalance.should.be.bignumber.equal(0)
       })
 
-      it.only('should register owner balance if it was transferred by operator', async function() {
+      it('should register owner balance if it was transferred by operator', async function() {
         await land.setApprovalForAll(operator, true, sentByUser)
         await land.transferLand(0, 1, creator, sentByOperator)
 

--- a/test/helpers/setupContracts.js
+++ b/test/helpers/setupContracts.js
@@ -4,6 +4,8 @@ export const ESTATE_SYMBOL = 'EST'
 export const LAND_NAME = 'Decentraland LAND'
 export const LAND_SYMBOL = 'LAND'
 
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
+
 export default async function setupContracts(creator) {
   const creationParams = {
     gas: 7e6,
@@ -15,6 +17,28 @@ export default async function setupContracts(creator) {
   const LANDRegistry = artifacts.require('LANDRegistryTest')
   const EstateRegistry = artifacts.require('EstateRegistryTest')
   const LANDProxy = artifacts.require('LANDProxy')
+  const MinimeToken = artifacts.require('MinimeToken')
+
+  const landMinimeToken = await MinimeToken.new(
+    EMPTY_ADDRESS,
+    EMPTY_ADDRESS,
+    0,
+    LAND_NAME,
+    18,
+    LAND_SYMBOL,
+    false,
+    creationParams
+  )
+  const estateMinimeToken = await MinimeToken.new(
+    EMPTY_ADDRESS,
+    EMPTY_ADDRESS,
+    0,
+    ESTATE_NAME,
+    18,
+    ESTATE_SYMBOL,
+    false,
+    creationParams
+  )
 
   const proxy = await LANDProxy.new(creationParams)
   const registry = await LANDRegistry.new(creationParams)
@@ -27,10 +51,17 @@ export default async function setupContracts(creator) {
     proxy.address,
     creationParams
   )
+  await estate.initAndChangeProxyOwner(creator)
 
   const land = await LANDRegistry.at(proxy.address)
   await land.initialize(creator, sentByCreator)
   await land.setEstateRegistry(estate.address)
+
+  await landMinimeToken.changeController(land.address, sentByCreator)
+  await land.setLandBalanceToken(landMinimeToken.address)
+
+  await estateMinimeToken.changeController(estate.address, sentByCreator)
+  await estate.setLandBalanceToken(estateMinimeToken.address)
 
   return {
     proxy,

--- a/test/helpers/setupContracts.js
+++ b/test/helpers/setupContracts.js
@@ -61,7 +61,7 @@ export default async function setupContracts(creator) {
   await land.setLandBalanceToken(landMinimeToken.address)
 
   await estateMinimeToken.changeController(estate.address, sentByCreator)
-  await estate.setLandBalanceToken(estateMinimeToken.address)
+  await estate.setEstateLandBalanceToken(estateMinimeToken.address)
 
   return {
     proxy,

--- a/test/helpers/setupContracts.js
+++ b/test/helpers/setupContracts.js
@@ -17,9 +17,9 @@ export default async function setupContracts(creator) {
   const LANDRegistry = artifacts.require('LANDRegistryTest')
   const EstateRegistry = artifacts.require('EstateRegistryTest')
   const LANDProxy = artifacts.require('LANDProxy')
-  const MinimeToken = artifacts.require('MinimeToken')
+  const MiniMeToken = artifacts.require('MiniMeToken')
 
-  const landMinimeToken = await MinimeToken.new(
+  const landMinimeToken = await MiniMeToken.new(
     EMPTY_ADDRESS,
     EMPTY_ADDRESS,
     0,
@@ -29,7 +29,7 @@ export default async function setupContracts(creator) {
     false,
     creationParams
   )
-  const estateMinimeToken = await MinimeToken.new(
+  const estateMinimeToken = await MiniMeToken.new(
     EMPTY_ADDRESS,
     EMPTY_ADDRESS,
     0,

--- a/test/helpers/setupContracts.js
+++ b/test/helpers/setupContracts.js
@@ -51,7 +51,6 @@ export default async function setupContracts(creator) {
     proxy.address,
     creationParams
   )
-  await estate.initAndChangeProxyOwner(creator)
 
   const land = await LANDRegistry.at(proxy.address)
   await land.initialize(creator, sentByCreator)


### PR DESCRIPTION
In order to be compliant with the Aragon DAO voting system. Decentraland will upgrade its Estate and LAND registry smart contracts to track the users’ balances as a MiniMEToken controlled by each contract. This MiniMeToken could be replaced with a new one in case it is needed.

- User decides they’d like to use their held LAND/Estates to vote
- They “register” on the LAND/Estate contract, and doing so will begin “tracking” their balance
  - In this operation, we use generateTokens() on the linked MiniMe for their current balance
- Afterwards, on any transfer, we check the from/to addresses if they’ve declared they’ve been registered, and adjust balances accordingly.
- At any point, a user can “deregister” to avoid having to spend gas on transfers

MiniMeTolen.sol: https://github.com/aragon/minime/blob/master/contracts/MiniMeToken.sol

