### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
 
 RUN apk add --no-cache python2 make g++ git bash
 


### PR DESCRIPTION
Sets the base image to `node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995` (was `node:10-alpine`) and pins it to an immutable sha256 digest for reproducible builds.